### PR TITLE
Refactor and one more test

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -1,46 +1,19 @@
 module FileIO
-import Base: read
-import Base: write
-import Base: (==)
-import Base: open
-import Base: abspath
-import Base: readbytes
-import Base: readall
-# package code goes here
 
+import Base: read,
+             write,
+             (==),
+             open,
+             abspath,
+             readbytes,
+             readall
 
-immutable File{Ending}
-	abspath::UTF8String
-end
+export File,
+       @file_str,
+       readformats,
+       writeformats,
+       ending
 
-function File(file)
-	@assert isfile(file) "file string doesn't refer to a file. Path: $file"
-	file = abspath(file)
-	_, ending = splitext(file)
-	File{symbol(lowercase(ending[2:end]))}(file)
-end
-macro file_str(path::AbstractString)
-	File(path)
-end
-File(folders...) = File(joinpath(folders...))
-ending{Ending}(::File{Ending}) = Ending
-(==)(a::File, b::File) = a.abspath == b.abspath
-open(x::File)       = open(abspath(x))
-abspath(x::File)    = x.abspath
-readbytes(x::File)  = readbytes(abspath(x))
-readall(x::File)    = readbytes(abspath(x))
-
-read{Ending}(f::File{Ending}; options...)  = error("no importer defined for file ending $T in path $(f.abspath), with options: $options")
-write{Ending}(f::File{Ending}; options...) = error("no exporter defined for file ending $T in path $(f.abspath), with options: $options")
-
-readformats{T}(backend::Val{T}) = error("Read backend $T not found.")
-writeformats{T}(backend::Val{T}) = error("Write backend $T not found.")
-
-export readformats
-export writeformats
-
-export ending
-export File
-export @file_str
+include("core.jl")     
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,4 @@ test_file = File("test.txt")
 @test abspath(test_file) === test_file.abspath
 @test ending(test_file)  === :txt
 
-@test_throw file"inexistent_file.txt"
+@test_throws file"inexistent_file.txt"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,11 @@
 using FileIO
 using Base.Test
 
-# write your own tests here
-test_file = File("test.jpg")
-@test file"test.jpg" == test_file
-@test test_file.abspath == Pkg.dir("FileIO", "test", "test.jpg")
-@test ending(test_file) == :jpg
+test_file = File("test.txt")
+
+@test file"test.txt" == test_file
+@test test_file.abspath  === Pkg.dir("FileIO", "test", "test.txt")
+@test abspath(test_file) === test_file.abspath
+@test ending(test_file)  === :txt
+
+@test_throw file"inexistent_file.txt"


### PR DESCRIPTION
Following the structure from most julia packages, FileIO.jl is just the module definition with imports, exports, etc. The functionality is defined on `core.jl` that is `include`d into the module definition.

I also added some comments and changed the tests for a `.txt` file that I created. I added a test for an inexistent file.