### PR TITLE
Support standard I/O operations on Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,21 +79,25 @@ In your package, write code like the following:
 using FileIO
 
 function load(f::File{format"PNG"})
-    io = open(f)
-    skipmagic(io, f)  # skip over the magic bytes
-    # Now do all the stuff you need to read a PNG file
+    s = open(f)
+    skipmagic(s)  # skip over the magic bytes
+    # You can just call the method below...
+    load(s)
+    # ...or implement everything here instead
 end
 
 # You can support streams and add keywords:
 function load(s::Stream{format"PNG"}; keywords...)
-    io = stream(s)  # io is positioned after the magic bytes
+    # s is already positioned after the magic bytes
     # Do the stuff to read a PNG file
+    chunklength = read(s, UInt32)
+    ...
 end
 
 function save(f::File{format"PNG"}, data)
-    io = open(f, "w")
+    s = open(f, "w")
     # Don't forget to write the magic bytes!
-    write(io, magic(format"PNG"))
+    write(s, magic(format"PNG"))
     # Do the rest of the stuff needed to save in PNG format
 end
 ```

--- a/src/query.jl
+++ b/src/query.jl
@@ -18,8 +18,7 @@ const unknown_df = DataFormat{:UNKNOWN}
 @doc """
 `unknown(f)` returns true if the format of `f` is unknown.""" ->
 unknown(::Type{format"UNKNOWN"}) = true
-unknown{sym}(::DataFormat{sym}) = unknown(sym)
-unknown(::Any) = false
+unknown{sym}(::Type{DataFormat{sym}}) = false
 
 const ext2sym = Dict{ASCIIString,Union(Symbol,Vector{Symbol})}()
 const magic_list = Array(Pair, 0)    # sorted, see magic_cmp below
@@ -165,9 +164,9 @@ immutable Stream{F<:DataFormat,IOtype<:IO} <: Formatted{F}
     filename::Nullable{UTF8String}
 end
 
-Stream(fmt::DataFormat, io::IO) = Stream{typeof(fmt),typeof(io)}(io, Nullable{UTF8String}())
-Stream(fmt::DataFormat, io::IO, filename::AbstractString) = Stream{typeof(fmt),typeof(io)}(io,utf8(filename))
-Stream(fmt::DataFormat, io::IO, filename) = Stream{typeof(fmt),typeof(io)}(io,filename)
+Stream{F<:DataFormat}(::Type{F}, io::IO) = Stream{F,typeof(io)}(io, Nullable{UTF8String}())
+Stream{F<:DataFormat}(::Type{F}, io::IO, filename::AbstractString) = Stream{F,typeof(io)}(io,utf8(filename))
+Stream{F<:DataFormat}(::Type{F}, io::IO, filename) = Stream{F,typeof(io)}(io,filename)
 Stream{F}(file::File{F}, io::IO) = Stream{F,typeof(io)}(io,filename(file))
 
 @doc "`stream(s)` returns the stream associated with `Stream` `s`" ->


### PR DESCRIPTION
Formerly `open(file::File)` used to return an `IOStream`, now it returns a `Stream`. This seems a necessary (or at least helpful) change to support incremental read/write operations (e.g., CSVReaders.jl).

This necessitates creating wrappers for most of Base's I/O operations for `Stream`.

This also adds a number of tests (currently Coverage.jl estimates coverage as 92%).
