### PR TITLE
Revert "added default load method"

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -36,7 +36,6 @@ include("query.jl")
 include("loadsave.jl")
 include("registry.jl")
 
-
 @doc """
 - `load(filename)` loads the contents of a formatted file, trying to infer
 the format from `filename` and/or magic bytes in the file.
@@ -63,16 +62,9 @@ function save(s::Union(AbstractString,IO), data...; options...)
     save(q, data...; options...)
 end
 
-# default load for packages which only define load on streams
-load(fn::File, args...; options...) = open(fn) do s
-    skipmagic(s)
-    load(s, args...; options...)
-end
-
 # Fallbacks
 load{F}(f::Formatted{F}; options...) = error("No load function defined for format ", F, " with filename ", filename(f))
 save{F}(f::Formatted{F}, data...; options...) = error("No save function defined for format ", F, " with filename ", filename(f))
-
 
 end # module
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -48,6 +48,12 @@ module Dummy
 
 using FileIO, Compat
 
+function FileIO.load(file::File{format"DUMMY"})
+    open(file) do s
+        skipmagic(s)
+        load(s)
+    end
+end
 
 function FileIO.load(s::Stream{format"DUMMY"})
     # We're already past the magic bytes


### PR DESCRIPTION
Reverts JuliaIO/FileIO.jl#24
It seems our favorite issue,  JuliaLang/Julia#265,  strucks us here.
The unspecific load functions gets compiled into load, which then gets not recompiled for any functions that get loaded at runtime.