### PR TITLE
allow for multiple loader/saver libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ add_loader(format"HDF5", :HDF5)
 add_saver(format"PNG", :ImageMagick)
 ```
 These packages will be automatically loaded as needed.
+You can also define the loaders and savers in a short form like this:
+```jl
+add_format(format"OFF", "OFF", ".off", [:MeshIO])
+```
+This means MeshIO supports loading and saving of the `off` format.
+You can add multiple loaders and specifiers like this:
+```jl
+add_format(
+    format"BMP", 
+    UInt8[0x42,0x4d],
+    ".bmp",
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+)
+```
+This means, OSXNative has first priority (gets loaded first) and only supports loading `bmp` on `OSX`.
+So on windows, `OSXNativeIO` will be ignored and `ImageMagick` has first priority.
+You can add any combination of `LOAD`, `SAVE`, `OSX`, `Unix`, `Windows` and `Linux`.
 
 Users are encouraged to contribute these definitions to the
 `registry.jl` file of this package, so that information about file

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -52,13 +52,12 @@ the magic bytes are essential.
 function load(s::@compat(Union{AbstractString,IO}), args...; options...)
     q = query(s)
     libraries = applicable_loaders(q)
-
+    last_exception = ErrorException("No library available to load $s")
     for library in libraries
         try
             check_loader(library)
             return load(q, args...; options...)
         catch e
-            warn(e)
             last_exception = e
         end
     end
@@ -74,14 +73,13 @@ trying to infer the format from `filename`.
 function save(s::@compat(Union{AbstractString,IO}), data...; options...)
     q = query(s)
     libraries = applicable_savers(q)
+    last_exception = ErrorException("No library available to save $s")
     for library in libraries
         try
-            println(library)
             check_saver(library)
             return save(q, data...; options...)
         catch e
-            warn(e)
-            last_exception = e
+            last_exception = e #TODO, better and standardized exception propagation system
         end
     end
     rethrow(last_exception)

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -55,8 +55,8 @@ function load(s::@compat(Union{AbstractString,IO}), args...; options...)
     last_exception = ErrorException("No library available to load $s")
     for library in libraries
         try
-            check_loader(library)
-            return load(q, args...; options...)
+            Library = check_loader(library)
+            return Library.load(q, args...; options...)
         catch e
             last_exception = e
         end
@@ -76,8 +76,8 @@ function save(s::@compat(Union{AbstractString,IO}), data...; options...)
     last_exception = ErrorException("No library available to save $s")
     for library in libraries
         try
-            check_saver(library)
-            return save(q, data...; options...)
+            Library = check_saver(library)
+            return Library.save(q, data...; options...)
         catch e
             last_exception = e #TODO, better and standardized exception propagation system
         end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -6,9 +6,9 @@ for (appl,fchk,fadd,dct) in ((:applicable_loaders, :check_loader, :add_loader, :
     @eval begin
         $appl{sym}(::Formatted{DataFormat{sym}}) = get($dct, sym, [:nothing])
         function $fchk(pkg::Symbol)
-            if !isdefined(Main, pkg)
-                eval(Main, Expr(:using, pkg))
-            end
+            pkg == :nothing && return FileIO #nothing is the symbol for no load/save specific lib. see above
+            !isdefined(Main, pkg) && eval(Main, Expr(:import, pkg))
+            return Main.(pkg)
         end
         function $fadd{sym}(::Type{DataFormat{sym}}, pkg::Symbol)
             list = get($dct, sym, Symbol[])

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -1,20 +1,18 @@
-const sym2loader = Dict{Symbol,Symbol}()
-const sym2saver  = Dict{Symbol,Symbol}()
+const sym2loader = Dict{Symbol,Vector{Symbol}}()
+const sym2saver  = Dict{Symbol,Vector{Symbol}}()
 
-for (fchk,fadd,dct) in ((:check_loader, :add_loader, :sym2loader),
-                        (:check_saver,  :add_saver,  :sym2saver))
+for (appl,fchk,fadd,dct) in ((:applicable_loaders, :check_loader, :add_loader, :sym2loader),
+                        (:applicable_savers, :check_saver,  :add_saver,  :sym2saver))
     @eval begin
-        function $fchk{sym}(::Formatted{DataFormat{sym}})
-            if haskey($dct, sym)
-                pkg = $dct[sym]
-                if !isdefined(Main, pkg)
-                    eval(Main, Expr(:using, pkg))
-                end
+        $appl{sym}(::Formatted{DataFormat{sym}}) = get($dct, sym, [:nothing])
+        function $fchk(pkg::Symbol)
+            if !isdefined(Main, pkg)
+                eval(Main, Expr(:using, pkg))
             end
         end
-
         function $fadd{sym}(::Type{DataFormat{sym}}, pkg::Symbol)
-            $dct[sym] = pkg
+            list = get($dct, sym, Symbol[])
+            $dct[sym] = push!(list, pkg)
         end
     end
 end

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,7 +1,5 @@
 ### Simple cases
-add_format(format"JLD", "Julia data file (HDF5)", ".jld")
-add_loader(format"JLD", :JLD)
-add_saver(format"JLD", :JLD)
+add_format(format"JLD", "Julia data file (HDF5)", ".jld", [:JLD])
 
 # Image formats
 add_format(format"PBMText",   b"P1", ".pbm")
@@ -11,83 +9,65 @@ add_format(format"PBMBinary", b"P4", ".pbm")
 add_format(format"PGMBinary", b"P5", ".pgm")
 add_format(format"PPMBinary", b"P6", ".ppm")
 
-add_format(format"NRRD", "NRRD", [".nrrd", ".nhdr"])
-add_loader(format"NRRD", :NRRD)
-add_saver(format"NRRD", :NRRD)
+add_format(format"NRRD", "NRRD", [".nrrd", ".nhdr"], [:NRRD])
 
-add_format(format"AndorSIF", "Andor Technology Multi-Channel File", ".sif")
-add_loader(format"AndorSIF", :AndorSIF)
+add_format(format"AndorSIF", "Andor Technology Multi-Channel File", ".sif", [:AndorSIF, LOAD])
 
-add_format(format"BMP", UInt8[0x42,0x4d], ".bmp")
-add_loader(format"BMP", :ImageMagick)
-add_saver(format"BMP", :ImageMagick)
-add_format(format"AVI", UInt8[0x52,0x49,0x46,0x46], ".avi")
-add_loader(format"AVI", :ImageMagick)
-add_saver(format"AVI", :ImageMagick)
-add_format(format"CRW", UInt8[0x49,0x49,0x1a,0x00,0x00,0x00,0x48,0x45], ".crw")
-add_loader(format"CRW", :ImageMagick)
-add_saver(format"CRW", :ImageMagick)
-add_format(format"CUR", UInt8[0x00,0x00,0x02,0x00], ".cur")
-add_loader(format"CUR", :ImageMagick)
-add_saver(format"CUR", :ImageMagick)
-add_format(format"DCX", UInt8[0xb1,0x68,0xde,0x3a], ".dcx")
-add_loader(format"DCX", :ImageMagick)
-add_saver(format"DCX", :ImageMagick)
-add_format(format"DOT", UInt8[0xd0,0xcf,0x11,0xe0,0xa1,0xb1,0x1a,0xe1], ".dot")
-add_loader(format"DOT", :ImageMagick)
-add_saver(format"DOT", :ImageMagick)
-add_format(format"EPS", UInt8[0x25,0x21,0x50,0x53,0x2d,0x41,0x64,0x6f], ".eps")
-add_loader(format"EPS", :ImageMagick)
-add_saver(format"EPS", :ImageMagick)
-add_format(format"GIF", UInt8[0x47,0x49,0x46,0x38], ".gif")
-add_loader(format"GIF", :ImageMagick)
-add_saver(format"GIF", :ImageMagick)
-add_format(format"HDR", UInt8[0x23,0x3f,0x52,0x41,0x44,0x49,0x41,0x4e], ".hdr")
-add_loader(format"HDR", :ImageMagick)
-add_saver(format"HDR", :ImageMagick)
-add_format(format"ICO", UInt8[0x00,0x00,0x01,0x00], ".ico")
-add_loader(format"ICO", :ImageMagick)
-add_saver(format"ICO", :ImageMagick)
-add_format(format"INFO", UInt8[0x7a,0x62,0x65,0x78], ".info")
-add_loader(format"INFO", :ImageMagick)
-add_saver(format"INFO", :ImageMagick)
-add_format(format"JP2", UInt8[0x00,0x00,0x00,0x0c,0x6a,0x50,0x20,0x20], ".jp2")
-add_loader(format"JP2", :ImageMagick)
-add_saver(format"JP2", :ImageMagick)
-add_format(format"JPEG", UInt8[0xff,0xd8,0xff],  [".jpeg", ".jpg", ".JPG"]) # 0xe1
-add_loader(format"JPEG", :ImageMagick)
-add_saver(format"JPEG", :ImageMagick)
-add_format(format"PCX", UInt8[0x0a,0x05,0x01,0x01], ".pcx")
-add_loader(format"PCX", :ImageMagick)
-add_saver(format"PCX", :ImageMagick)
-add_format(format"PDB", UInt8[0x73,0x7a,0x65,0x7a], ".pdb")
-add_loader(format"PDB", :ImageMagick)
-add_saver(format"PDB", :ImageMagick)
-add_format(format"PDF", UInt8[0x25,0x50,0x44,0x46], ".pdf")
-add_loader(format"PDF", :ImageMagick)
-add_saver(format"PDF", :ImageMagick)
-add_format(format"PGM", UInt8[0x50,0x35,0x0a], ".pgm")
-add_loader(format"PGM", :ImageMagick)
-add_saver(format"PGM", :ImageMagick)
-add_format(format"PNG", UInt8[0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a], ".png")
-add_loader(format"PNG", :ImageMagick)
-add_saver(format"PNG", :ImageMagick)
-add_format(format"PSD", UInt8[0x38,0x42,0x50,0x53], ".psd")
-add_loader(format"PSD", :ImageMagick)
-add_saver(format"PSD", :ImageMagick)
-add_format(format"RGB", UInt8[0x01,0xda,0x01,0x01,0x00,0x03], ".rgb")
-add_loader(format"RGB", :ImageMagick)
-add_saver(format"RGB", :ImageMagick)
 
-add_format(format"TIFF", (UInt8[0x4d,0x4d,0x00,0x2a], UInt8[0x4d,0x4d,0x00,0x2b], UInt8[0x49,0x49,0x2a,0x00]), [".tiff", ".tif"])
-add_loader(format"TIFF", :ImageMagick)
-add_saver(format"TIFF", :ImageMagick)
-add_format(format"WMF", UInt8[0xd7,0xcd,0xc6,0x9a], ".wmf")
-add_loader(format"WMF", :ImageMagick)
-add_saver(format"WMF", :ImageMagick)
-add_format(format"WPG", UInt8[0xff,0x57,0x50,0x43], ".wpg")
-add_loader(format"WPG", :ImageMagick)
-add_saver(format"WPG", :ImageMagick)
+add_format(format"AVI", UInt8[0x52,0x49,0x46,0x46],                     ".avi", [:ImageMagick])
+add_format(format"CRW", UInt8[0x49,0x49,0x1a,0x00,0x00,0x00,0x48,0x45], ".crw", [:ImageMagick])
+add_format(format"CUR", UInt8[0x00,0x00,0x02,0x00],                     ".cur", [:ImageMagick])
+add_format(format"DCX", UInt8[0xb1,0x68,0xde,0x3a],                     ".dcx", [:ImageMagick])
+add_format(format"DOT", UInt8[0xd0,0xcf,0x11,0xe0,0xa1,0xb1,0x1a,0xe1], ".dot", [:ImageMagick])
+add_format(format"EPS", UInt8[0x25,0x21,0x50,0x53,0x2d,0x41,0x64,0x6f], ".eps", [:ImageMagick])
+add_format(format"HDR", UInt8[0x23,0x3f,0x52,0x41,0x44,0x49,0x41,0x4e], ".hdr", [:ImageMagick])
+add_format(format"ICO", UInt8[0x00,0x00,0x01,0x00],                     ".ico", [:ImageMagick])
+add_format(format"INFO", UInt8[0x7a,0x62,0x65,0x78],                    ".info",[:ImageMagick])
+add_format(format"JP2", UInt8[0x00,0x00,0x00,0x0c,0x6a,0x50,0x20,0x20], ".jp2", [:ImageMagick])
+add_format(format"PCX", UInt8[0x0a,0x05,0x01,0x01],                     ".pcx", [:ImageMagick])
+add_format(format"PDB", UInt8[0x73,0x7a,0x65,0x7a],                     ".pdb", [:ImageMagick])
+add_format(format"PDF", UInt8[0x25,0x50,0x44,0x46],                     ".pdf", [:ImageMagick])
+add_format(format"PGM", UInt8[0x50,0x35,0x0a],                          ".pgm", [:ImageMagick])
+add_format(format"PSD", UInt8[0x38,0x42,0x50,0x53],                     ".psd", [:ImageMagick])
+add_format(format"RGB", UInt8[0x01,0xda,0x01,0x01,0x00,0x03],           ".rgb", [:ImageMagick])
+add_format(format"WMF", UInt8[0xd7,0xcd,0xc6,0x9a],                     ".wmf", [:ImageMagick])
+add_format(format"WPG", UInt8[0xff,0x57,0x50,0x43],                     ".wpg", [:ImageMagick])
+
+add_format(
+    format"GIF", 
+    UInt8[0x47,0x49,0x46,0x38],
+    ".gif", 
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+)
+add_format(
+    format"PNG", 
+    UInt8[0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a], 
+    ".png", 
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+)
+add_format(
+    format"TIFF", 
+    (UInt8[0x4d,0x4d,0x00,0x2a], UInt8[0x4d,0x4d,0x00,0x2b], UInt8[0x49,0x49,0x2a,0x00]), 
+    [".tiff", ".tif"], 
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+)
+add_format(
+    format"JPEG", 
+    UInt8[0xff,0xd8,0xff],
+    [".jpeg", ".jpg", ".JPG"], 
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+) # 0xe1
+add_format(
+    format"BMP", 
+    UInt8[0x42,0x4d],
+    ".bmp",
+    [:OSXNativeIO, LOAD, OSX], 
+    [:ImageMagick]
+)
 
 #=
 add_format(format"NPY", UInt8[0x93, 'N', 'U', 'M', 'P', 'Y'], ".npy")
@@ -100,30 +80,14 @@ add_saver(format"ZIP", :ZipeFile)
 =#
 
 #Shader files
-add_format(format"GLSLShader", (), [".frag", ".vert", ".geom", ".comp"])
-add_loader(format"GLSLShader", :GLAbstraction)
-add_saver(format"GLSLShader", :GLAbstraction)
+add_format(format"GLSLShader", (), [".frag", ".vert", ".geom", ".comp"], [:GLAbstraction])
 
 # Mesh formats
-add_format(format"OBJ", (), ".obj")
-add_loader(format"OBJ", :MeshIO)
-add_saver(format"OBJ", :MeshIO)
-
-add_format(format"PLY_ASCII", "ply\nformat ascii 1.0", ".ply")
-add_format(format"PLY_BINARY", "ply\nformat binary_little_endian 1.0", ".ply")
-
-add_loader(format"PLY_ASCII", :MeshIO)
-add_loader(format"PLY_BINARY", :MeshIO)
-add_saver(format"PLY_ASCII", :MeshIO)
-add_saver(format"PLY_BINARY", :MeshIO)
-
-add_format(format"2DM", "MESH2D", ".2dm")
-add_loader(format"2DM", :MeshIO)
-add_saver(format"2DM", :MeshIO)
-
-add_format(format"OFF", "OFF", ".off")
-add_loader(format"OFF", :MeshIO)
-add_saver(format"OFF", :MeshIO)
+add_format(format"OBJ", (), ".obj", [:MeshIO])
+add_format(format"PLY_ASCII", "ply\nformat ascii 1.0", ".ply", [:MeshIO])
+add_format(format"PLY_BINARY", "ply\nformat binary_little_endian 1.0", ".ply", [:MeshIO])
+add_format(format"2DM", "MESH2D", ".2dm", [:MeshIO])
+add_format(format"OFF", "OFF", ".off", [:MeshIO])
 
 
 
@@ -150,10 +114,7 @@ function detecthdf5(io)
     end
     false
 end
-add_format(format"HDF5", detecthdf5, [".h5", ".hdf5"])
-add_loader(format"HDF5", :HDF5)
-add_saver(format"HDF5", :HDF5)
-
+add_format(format"HDF5", detecthdf5, [".h5", ".hdf5"], [:HDF5])
 
 function detect_stlascii(io)
     try
@@ -190,10 +151,6 @@ function detect_stlbinary(io)
     seekstart(io)
     return result
 end
-add_format(format"STL_ASCII", detect_stlascii, [".stl", ".STL"])
-add_format(format"STL_BINARY", detect_stlbinary, [".stl", ".STL"])
-add_loader(format"STL_ASCII", :MeshIO)
-add_saver(format"STL_BINARY", :MeshIO)
-add_saver(format"STL_ASCII", :MeshIO)
-add_loader(format"STL_BINARY", :MeshIO)
+add_format(format"STL_ASCII", detect_stlascii, [".stl", ".STL"], [:MeshIO])
+add_format(format"STL_BINARY", detect_stlbinary, [".stl", ".STL"], [:MeshIO])
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -15,7 +15,7 @@ try
     empty!(FileIO.sym2loader)
     empty!(FileIO.sym2saver)
     file_dir = joinpath(dirname(@__FILE__), "files")
-    facts("Load") do
+    context("Load") do
         @fact load(joinpath(file_dir, "file1.pbm")) --> "PBMText"
         @fact load(joinpath(file_dir, "file2.pbm")) --> "PBMBinary"
         # Regular HDF5 file with magic bytes starting at position 0
@@ -78,7 +78,7 @@ end
 add_loader(format"DUMMY", :Dummy)
 add_saver(format"DUMMY", :Dummy)
 
-facts("Save") do
+context("Save") do
     a = [0x01,0x02,0x03]
     fn = string(tempname(), ".dmy")
     save(fn, a)

--- a/test/query.jl
+++ b/test/query.jl
@@ -219,20 +219,17 @@ try
         @fact lenload0 + 1 --> length(FileIO.sym2loader)
         @fact length(FileIO.sym2loader[:MultiLib]) --> 2
         @fact length(FileIO.sym2saver[:MultiLib]) --> 1
-
-        mktempdir() do tmpdir
-            fn = joinpath(tmpdir, "test.mlb")
-            save(fn)
-            x = load(fn)
-            open(query(fn), "r") do io
-                skipmagic(io)
-                a = read(io, Int)
-                @fact a --> 42 #make sure that LoadTest2 is used for saving, even though its at position 2
-            end
-            @fact isdefined(:LoadTest1) --> true # first module should load first but fail
-            @fact x --> 42
+        fn = string(tempname(), ".mlb")
+        save(fn)
+        x = load(fn)
+        open(query(fn), "r") do io
+            skipmagic(io)
+            a = read(io, Int)
+            @fact a --> 42 #make sure that LoadTest2 is used for saving, even though its at position 2
         end
-
+        @fact isdefined(:LoadTest1) --> true # first module should load first but fail
+        @fact x --> 42
+        rm(fn)
     end
 finally
     # Restore the registry

--- a/test/query.jl
+++ b/test/query.jl
@@ -11,12 +11,34 @@ ext2sym = copy(FileIO.ext2sym)
 magic_list = copy(FileIO.magic_list)
 sym2info = copy(FileIO.sym2info)
 
+
+module LoadTest1
+import FileIO: @format_str, File
+load(file::File{format"MultiLib"}) = error()
+
+save(file::File{format"MultiLib"}) = open(file, "w") do s
+    write(s, magic(format"MultiLib"))  # Write the magic bytes
+    write(s, 0)
+end
+
+end
+module LoadTest2
+import FileIO: @format_str, File, magic
+load(file::File{format"MultiLib"}) = 42
+
+save(file::File{format"MultiLib"}) = open(file, "w") do s
+    write(s, magic(format"MultiLib"))  # Write the magic bytes
+    write(s, 42)
+end
+
+end
+
 try
     empty!(FileIO.ext2sym)
     empty!(FileIO.magic_list)
     empty!(FileIO.sym2info)
 
-    facts("DataFormat") do
+    context("DataFormat") do
         @fact DataFormat{:CSV} --> format"CSV"
         @fact unknown(format"CSV") --> false
         @fact unknown(format"UNKNOWN") --> true
@@ -44,7 +66,7 @@ try
 
     end
 
-    facts("streams") do
+    context("streams") do
         io = IOBuffer()
         s = Stream(format"JUNK", io)
         @fact typeof(s) --> Stream{DataFormat{:JUNK}, IOBuffer}
@@ -56,7 +78,7 @@ try
         @fact get(filename(s)) --> "junk2.jnk"
     end
 
-    facts("query") do
+    context("query") do
         # Streams
         io = IOBuffer()
         write(io, "Weird format")
@@ -182,6 +204,36 @@ try
 
     del_format(format"JUNK")  # This triggers del_extension for multiple extensions
 
+    context("multiple libs") do
+        lensave0 = length(FileIO.sym2saver)
+        lenload0 = length(FileIO.sym2loader)
+        OSKey = @osx ? FileIO.OSX : @windows? FileIO.Windows : @linux ? FileIO.Linux : error("os not supported")
+        add_format(
+            format"MultiLib", 
+            UInt8[0x42,0x4d],
+            ".mlb",
+            [:LoadTest1, FileIO.LOAD, OSKey], 
+            [:LoadTest2]
+        )
+        @fact lensave0 + 1 --> length(FileIO.sym2saver)
+        @fact lenload0 + 1 --> length(FileIO.sym2loader)
+        @fact length(FileIO.sym2loader[:MultiLib]) --> 2
+        @fact length(FileIO.sym2saver[:MultiLib]) --> 1
+
+        mktempdir() do tmpdir
+            fn = joinpath(tmpdir, "test.mlb")
+            save(fn)
+            x = load(fn)
+            open(query(fn), "r") do io
+                skipmagic(io)
+                a = read(io, Int)
+                @fact a --> 42 #make sure that LoadTest2 is used for saving, even though its at position 2
+            end
+            @fact isdefined(:LoadTest1) --> true # first module should load first but fail
+            @fact x --> 42
+        end
+
+    end
 finally
     # Restore the registry
     empty!(FileIO.ext2sym)
@@ -194,7 +246,7 @@ finally
 end
 
 file_dir = joinpath(dirname(@__FILE__), "files")
-facts("STL detection") do 
+context("STL detection") do 
     q = query(joinpath(file_dir, "ascii.stl"))
     @fact typeof(q) --> File{format"STL_ASCII"}
     q = query(joinpath(file_dir, "binary_stl_from_solidworks.STL"))
@@ -205,14 +257,14 @@ facts("STL detection") do
         @fact position(io) --> 0 # no skipping for functions
     end
 end
-facts("PLY detection") do 
+context("PLY detection") do 
     q = query(joinpath(file_dir, "ascii.ply"))
     @fact typeof(q) --> File{format"PLY_ASCII"}
     q = query(joinpath(file_dir, "binary.ply"))
     @fact typeof(q) --> File{format"PLY_BINARY"}
 
 end
-facts("Multiple Magic bytes") do 
+context("Multiple Magic bytes") do 
     q = query(joinpath(file_dir, "magic1.tiff"))
     @fact typeof(q) --> File{format"TIFF"}
     q = query(joinpath(file_dir, "magic2.tiff"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using FileIO
 using FactCheck
 
-include("query.jl")
-include("loadsave.jl")
-
+facts("FileIO") do
+	include("query.jl")
+	include("loadsave.jl")
+end
 # make Travis fail when tests fail:
 FactCheck.exitstatus()


### PR DESCRIPTION
and a more concise way to define default load/save library.
From Readme update:
You can also define the loaders and savers in a short form like this:
```Julia
add_format(format"OFF", "OFF", ".off", [:MeshIO])
```
This means MeshIO supports loading and saving of the `off` format.
You can add multiple loaders and specifiers like this:
```Julia
add_format(
    format"BMP", 
    UInt8[0x42,0x4d],
    ".bmp",
    [:OSXNativeIO, LOAD, OSX], 
    [:ImageMagick]
)
```
This means, OSXNative has first priority (gets loaded first) and only supports loading `bmp` on `OSX`.
So on windows, `OSXNativeIO` will be ignored and `ImageMagick` has first priority.
You can add any combination of `LOAD`, `SAVE`, `OSX`, `Unix`, `Windows` and `Linux`.
