### PR TITLE
Add support for writemime

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -1,8 +1,10 @@
 const sym2loader = Dict{Symbol,Vector{Symbol}}()
 const sym2saver  = Dict{Symbol,Vector{Symbol}}()
+const mimedict   = Dict{Symbol,Vector{Any}}()
 
-for (appl,fchk,fadd,dct) in ((:applicable_loaders, :check_loader, :add_loader, :sym2loader),
-                        (:applicable_savers, :check_saver,  :add_saver,  :sym2saver))
+for (appl,fchk,fadd,dct) in (
+        (:applicable_loaders, :check_loader, :add_loader, :sym2loader),
+        (:applicable_savers,  :check_saver,  :add_saver,  :sym2saver))
     @eval begin
         $appl{sym}(::Formatted{DataFormat{sym}}) = get($dct, sym, [:nothing])
         function $fchk(pkg::Symbol)
@@ -17,5 +19,20 @@ for (appl,fchk,fadd,dct) in ((:applicable_loaders, :check_loader, :add_loader, :
     end
 end
 
-@doc "`add_loader(fmt, :Package)` forces `using Package` before loading format `fmt`" -> add_loader
-@doc "`add_saver(fmt, :Package)` forces `using Package` before saving format `fmt`" -> add_saver
+applicable_mime{sym}(::MIME{sym}) = get(mimedict, sym, [:nothing])
+function check_mime(pkg::Symbol)
+    pkg == :nothing && error("No MIME package available")
+    !isdefined(Main, pkg) && eval(Main, Expr(:import, pkg))
+    return pkg
+end
+
+@doc """
+`add_mime(mime, T, :Package)`  triggers `using Package` before attempting to write object of type `T` in format `mime`.
+""" ->
+function add_mime{sym,T}(::MIME{sym}, ::Type{T}, pkg::Symbol)
+    list = get(mimedict, sym, Any[])
+    mimedict[sym] = push!(list, (T,pkg))
+end
+
+@doc "`add_loader(fmt, :Package)` triggers `using Package` before loading format `fmt`" -> add_loader
+@doc "`add_saver(fmt, :Package)` triggers `using Package` before saving format `fmt`" -> add_saver

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using FactCheck
 facts("FileIO") do
 	include("query.jl")
 	include("loadsave.jl")
+	include("writemime.jl")
 end
 # make Travis fail when tests fail:
 FactCheck.exitstatus()

--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -1,0 +1,9 @@
+Base.writemime(s::Stream{format"FileIO"}, ::MIME"test/floatvector", v::Vector{Float32}) = print(stream(s), v)
+context("writemime") do 
+	add_mime(MIME("test/floatvector"), Vector{Float32}, :FileIO)
+	io = IOBuffer()
+	t = rand(Float32, 88)
+	writemime(io, MIME("test/floatvector"), t)
+	@fact takebuf_string(io) --> string(t)
+	close(io)
+end


### PR DESCRIPTION
This tries to support `writemime` in a manner similar to the file format API. In this case, the main challenge is handling the "data" argument of `writemime`, whose type may be defined in a package. Consequently, we expect the `add_mime` calls will often be made from external packages.

The main advantage this brings, over "static" implementation of `writemime`, is the ability to select different implementations based on installed packages, etc.

CC @SimonDanisch, @stevengj.