### PR TITLE
Choose a default for ambiguous formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
   email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone("https://github.com/JuliaIO/Netpbm.jl.git")'
     - julia -e 'Pkg.clone(pwd()); Pkg.build("FileIO"); Pkg.test("FileIO"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("FileIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -115,7 +115,7 @@ function Base.writemime(io::IO, mime::MIME, x)
 end
 
 # Fallbacks
-load{F}(f::Formatted{F}; options...) = error("No load function defined for format ", F, " with filename ", filename(f))
+load{F}(f::Formatted{F}, args...; options...) = error("No load function defined for format ", F, " with filename ", filename(f))
 save{F}(f::Formatted{F}, data...; options...) = error("No save function defined for format ", F, " with filename ", filename(f))
 
 end # module

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -86,6 +86,19 @@ function save(s::@compat(Union{AbstractString,IO}), data...; options...)
     rethrow(last_exception)
 end
 
+# Forced format
+function save{sym}(::Type{DataFormat{sym}}, f::AbstractString, data...; options...)
+    libraries = sym2saver[sym]
+    check_saver(libraries[1])
+    save(File(DataFormat{sym}, f), data...; options...)
+end
+
+function save{sym}(::Type{DataFormat{sym}}, s::IO, data...; options...)
+    libraries = sym2saver[sym]
+    check_saver(libraries[1])
+    save(Stream(DataFormat{sym}, s), data...; options...)
+end
+
 function Base.writemime(io::IO, mime::MIME, x)
     handlers = applicable_mime(mime)
     last_exception = ErrorException("No package available to writemime $mime")

--- a/src/query.jl
+++ b/src/query.jl
@@ -352,7 +352,7 @@ function query(filename::AbstractString)
         if lensym(sym) == 1 && (no_magic || !isfile(filename)) # we only found one candidate and there is no magic bytes, or no file, trust the extension
             return File{DataFormat{sym}}(filename)
         elseif !isfile(filename) && lensym(sym) > 1
-            error("no file for check of magic bytes and multiple extensions possible: $sym")
+            return File{DataFormat{sym[1]}}(filename)
         end
         if no_magic && !hasfunction(sym)
             error("Some formats with extension ", ext, " have no magic bytes; use `File{format\"FMT\"}(filename)` to resolve the ambiguity.")

--- a/src/query.jl
+++ b/src/query.jl
@@ -1,6 +1,6 @@
 ### Format registry infrastructure
-abstract OS 
-abstract Unix <: OS 
+abstract OS
+abstract Unix <: OS
 immutable Windows <: OS end
 immutable OSX <: Unix end
 immutable Linux <: Unix end
@@ -424,7 +424,7 @@ function iter_eq(A, B)
         a=A[i]; b=B[j]
         a == b && (i+=1; j+=1; continue)
         a == '\r' && (i+=1; continue) # this seems like the shadiest solution to deal with windows \r\n
-        b == '\r' && (j+=1; continue) 
+        b == '\r' && (j+=1; continue)
         return false #now both must be unequal, and no \r windows excemption any more
     end
     true

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -2,12 +2,12 @@
 add_format(format"JLD", "Julia data file (HDF5)", ".jld", [:JLD])
 
 # Image formats
-add_format(format"PBMText",   b"P1", ".pbm")
-add_format(format"PGMText",   b"P2", ".pgm")
-add_format(format"PPMText",   b"P3", ".ppm")
-add_format(format"PBMBinary", b"P4", ".pbm")
-add_format(format"PGMBinary", b"P5", ".pgm")
-add_format(format"PPMBinary", b"P6", ".ppm")
+add_format(format"PBMBinary", b"P4", ".pbm", [:ImageMagick])
+add_format(format"PGMBinary", b"P5", ".pgm", [:Netpbm])
+add_format(format"PPMBinary", b"P6", ".ppm", [:Netpbm])
+add_format(format"PBMText",   b"P1", ".pbm", [:ImageMagick, LOAD])
+add_format(format"PGMText",   b"P2", ".pgm", [:ImageMagick, LOAD])
+add_format(format"PPMText",   b"P3", ".ppm", [:ImageMagick, LOAD])
 
 add_format(format"NRRD", "NRRD", [".nrrd", ".nhdr"], [:NRRD])
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,4 @@
 FactCheck
+Images
+Netpbm
+ImageMagick

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -115,3 +115,23 @@ context("Save") do
 end
 
 del_format(format"DUMMY")
+
+# PPM/PBM can be either binary or text. Test that the defaults work,
+# and that we can force a choice.
+using Images
+context("Ambiguous extension") do
+    A = rand(UInt8, 3, 2)
+    fn = string(tempname(), ".pgm")
+    # Test the forced version first: we wouldn't want some method in Netpbm
+    # coming to the rescue here, we want to rely on FileIO's logic.
+    # `save(fn, A)` will load Netpbm, which could conceivably mask a failure
+    # in the next line.
+    save(format"PGMBinary", fn, A)
+    B = load(fn)
+    @fact raw(convert(Array, B)) --> A
+    save(fn, A)
+    B = load(fn)
+    @fact raw(convert(Array, B)) --> A
+
+    rm(fn)
+end

--- a/test/query.jl
+++ b/test/query.jl
@@ -148,7 +148,6 @@ try
         add_format(format"DOUBLE_1", "test1", ".double")
         add_format(format"DOUBLE_2", "test2", ".double")
 
-        @fact_throws ErrorException query( "test.double")
         fn = string(tempname(), ".double")
         open(fn, "w") do file
             write(file, "test1")
@@ -209,10 +208,10 @@ try
         lenload0 = length(FileIO.sym2loader)
         OSKey = @osx ? FileIO.OSX : @windows? FileIO.Windows : @linux ? FileIO.Linux : error("os not supported")
         add_format(
-            format"MultiLib", 
+            format"MultiLib",
             UInt8[0x42,0x4d],
             ".mlb",
-            [:LoadTest1, FileIO.LOAD, OSKey], 
+            [:LoadTest1, FileIO.LOAD, OSKey],
             [:LoadTest2]
         )
         @fact lensave0 + 1 --> length(FileIO.sym2saver)
@@ -243,25 +242,25 @@ finally
 end
 
 file_dir = joinpath(dirname(@__FILE__), "files")
-context("STL detection") do 
+context("STL detection") do
     q = query(joinpath(file_dir, "ascii.stl"))
     @fact typeof(q) --> File{format"STL_ASCII"}
     q = query(joinpath(file_dir, "binary_stl_from_solidworks.STL"))
     @fact typeof(q) --> File{format"STL_BINARY"}
-    open(q) do io 
+    open(q) do io
         @fact position(io) --> 0
         skipmagic(io)
         @fact position(io) --> 0 # no skipping for functions
     end
 end
-context("PLY detection") do 
+context("PLY detection") do
     q = query(joinpath(file_dir, "ascii.ply"))
     @fact typeof(q) --> File{format"PLY_ASCII"}
     q = query(joinpath(file_dir, "binary.ply"))
     @fact typeof(q) --> File{format"PLY_BINARY"}
 
 end
-context("Multiple Magic bytes") do 
+context("Multiple Magic bytes") do
     q = query(joinpath(file_dir, "magic1.tiff"))
     @fact typeof(q) --> File{format"TIFF"}
     q = query(joinpath(file_dir, "magic2.tiff"))


### PR DESCRIPTION
`save("myfile.ppm", img)` used to generate an error, because there are two formats (`:PPMBinary` and `:PPMText`) defined. Users will rarely care, and in almost all cases you want `:PPMBinary` anyway. So I changed the behavior from "throw an error upon creating a new file when the format is ambiguous" to "choose the first one in the list".

I also provided a new mechanism for forcing the format: `save(format"PPMBinary", "myfile.ppm", img)`. You might have thought that `save(File(format"PPMBinary", "myfile.ppm"), img)` would have been the better choice, but that runs into a problem: unless the (new) Netpbm.jl package has already been manually loaded, it falls back to the "error: no saver defined for ..." method. So we need a method with distinguishable signature, and this seemed to be the obvious one.
