### PR TITLE
Fix OS detection

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -13,8 +13,8 @@ applies_to_os(os::Vector) = isempty(os) || any(applies_to_os, os)
 applies_to_os{O <: OS}(os::Type{O}) = false
 @unix_only applies_to_os{U <: Unix}(os::Type{U}) = true
 @windows_only applies_to_os(os::Type{Windows})   = true
-@osx_only applies_to_os(os::Type{OSX})           = true
-@linux_only applies_to_os(os::Type{Linux})       = true
+@linux_only applies_to_os(os::Type{OSX})         = false
+@osx_only applies_to_os(os::Type{Linux})         = false
 
 function add_loadsave(format, predicates)
     library = shift!(predicates)

--- a/test/query.jl
+++ b/test/query.jl
@@ -6,6 +6,27 @@ if VERSION < v"0.4.0-dev"
     import FileIO.Pair
 end
 
+context("OS") do
+    @linux_only begin
+        @fact FileIO.applies_to_os(FileIO.Linux)   --> true
+        @fact FileIO.applies_to_os(FileIO.OSX)     --> false
+        @fact FileIO.applies_to_os(FileIO.Unix)    --> true
+        @fact FileIO.applies_to_os(FileIO.Windows) --> false
+    end
+    @osx_only begin
+        @fact FileIO.applies_to_os(FileIO.Linux)   --> false
+        @fact FileIO.applies_to_os(FileIO.OSX)     --> true
+        @fact FileIO.applies_to_os(FileIO.Unix)    --> true
+        @fact FileIO.applies_to_os(FileIO.Windows) --> false
+    end
+    @windows_only begin
+        @fact FileIO.applies_to_os(FileIO.Linux)   --> false
+        @fact FileIO.applies_to_os(FileIO.OSX)     --> false
+        @fact FileIO.applies_to_os(FileIO.Unix)    --> false
+        @fact FileIO.applies_to_os(FileIO.Windows) --> true
+    end
+end
+
 # Before we bork things, make a copy
 ext2sym = copy(FileIO.ext2sym)
 magic_list = copy(FileIO.magic_list)


### PR DESCRIPTION
On Linux I was seeing QuartzImageIO rebuild and it turns out to have been because of
```jl
@unix_only applies_to_os{U <: Unix}(os::Type{U}) = true
```
Consequently, we don't have to rule-in our platform, but we do have to rule-out other Unices.
