### PR TITLE
RFC: Add LoaderError and WriterError exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
When throwing these errors in library code, FileIO will
emit an info message and then try the next registered loader / writer.

Simon pointed me in the right direction for this.

Worth a naming check, and perhaps some tests before merging?