### PR TITLE
Report the library that triggered the error

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -46,10 +46,10 @@ Base.showerror(io::IO, e::UnknownFormat) = println(io, e.format, " couldn't be r
 @doc """
 Handles error as soon as they get thrown while doing IO
 """ ->
-function handle_current_error(e, islast)
+function handle_current_error(e, library, islast::Bool)
     bt = catch_backtrace()
     bts = sprint(io->Base.show_backtrace(io, bt))
-    message = islast ? "" : "\nTrying next loading library! Please report this issue on Github"
+    message = islast ? "" : "\nTrying next loading library! Please report this issue on the Github page for $library"
     warn(string(e, bts, message))
 end
 handle_current_error(e::NotInstalledError) = warn(string("lib ", e.library, " not installed, trying next library"))

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -76,7 +76,7 @@ function load{F}(q::Formatted{F}, args...; options...)
             Library = checked_import(library)
             return Library.load(q, args...; options...)
         catch e
-            handle_current_error(e, library == last(libraries))
+            handle_current_error(e, library, library == last(libraries))
             push!(failures, (e, q))
         end
     end
@@ -91,7 +91,7 @@ function save{F}(q::Formatted{F}, data...; options...)
             Library = checked_import(library)
             return Library.save(q, data...; options...)
         catch e
-            handle_current_error(e, library == last(libraries))
+            handle_current_error(e, library, library == last(libraries))
             push!(failures, (e, q))
         end
     end


### PR DESCRIPTION
Before this change, it was unclear exactly where to file Github issues.  This expands the error message to include the library with the error along with the instructions.