### PR TITLE
Clarify load errors

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -43,13 +43,6 @@ include("error_handling.jl")
 include("loadsave.jl")
 include("registry.jl")
 
-
-end # module
-
-if VERSION < v"0.4.0-dev"
-    using Docile
-end
-
 @doc """
 `FileIO` API (brief summary, see individual functions for more detail):
 
@@ -73,3 +66,5 @@ end
 - `add_loader(fmt, :Package)`: indicate that `Package` supports loading files of type `fmt`
 - `add_saver(fmt, :Package)`: indicate that `Package` supports saving files of type `fmt`
 """ -> FileIO
+
+end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -49,7 +49,7 @@ trying to infer the format from `filename`.
 - `save(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
 - `save(f, data...; options...)` passes keyword arguments on to the saver.
 """ ->
-save(s::@compat(Union{AbstractString,IO}), data...; options...) = 
+save(s::@compat(Union{AbstractString,IO}), data...; options...) =
     save(query(s), data...; options...)
 
 # Forced format
@@ -68,7 +68,10 @@ end
 
 # Fallbacks
 function load{F}(q::Formatted{F}, args...; options...)
-    unknown(q) && throw(UnknownFormat(q))
+    if unknown(q)
+        isfile(filename(q)) || open(filename(q))  # force systemerror
+        throw(UnknownFormat(q))
+    end
     libraries   = applicable_loaders(q)
     failures    = Any[]
     for library in libraries

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -174,3 +174,7 @@ context("Ambiguous extension") do
 
     rm(fn)
 end
+
+context("Absent file") do
+    @fact_throws SystemError load("nonexistent.oops")
+end


### PR DESCRIPTION
Before:
```jl
julia> load("nonexistent.oops")
ERROR: FileIO.File{FileIO.DataFormat{:UNKNOWN}}("nonexistent.oops") couldn't be recognized by FileIO.
 in load at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:71
 in load at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:42
```
Now:
```jl
julia> load("nonexistent.oops")
ERROR: SystemError: opening file nonexistent.oops: No such file or directory
 in open at ./iostream.jl:90
 in load at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:72
 in load at /home/tim/.julia/v0.4/FileIO/src/loadsave.jl:42
```

CC @alexmulo.
