### PR TITLE
Use `WAV.jl` for `.wav` files

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -108,7 +108,7 @@ function detectwav(io)
 
     submagic == b"WAVE"
 end
-add_format(format"WAV", detectwav, "wav", [:FLAC])
+add_format(format"WAV", detectwav, ".wav", [:WAV])
 add_format(format"FLAC","fLaC",".flac",[:FLAC])
 
 


### PR DESCRIPTION
It turns out `FLAC.jl`'s `.wav` handling is worse than I thought, so I've switched this over to `WAV.jl`, what a surprise.