### PR TITLE
Implement loadstreaming/savestreaming API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ file format.
 Sometimes you want to read or write files that are larger than your available
 memory, or might be an unknown or infinite length (e.g. reading an audio or
 video stream from a socket). In these cases it might not make sense to process
-the whole file at once, but instead process it a chunk at a time. For these situations FileIO provides the `loadstreaming` and `savestreaming` functions, which return an object that you can `read` or `write`, rather than the file data itself.
+the whole file at once, but instead process it a chunk at a time. For these
+situations FileIO provides the `loadstreaming` and `savestreaming` functions,
+which return an object that you can `read` or `write`, rather than the file data
+itself.
 
 This would look something like:
 
@@ -69,7 +72,8 @@ do loadstreaming("bigfile.wav") audio
 end
 ```
 
-Note that in these cases you may want to use `read!` with a pre-allocated buffer for maximum efficiency.
+Note that in these cases you may want to use `read!` with a pre-allocated buffer
+for maximum efficiency.
 
 ## Adding new formats
 
@@ -173,7 +177,13 @@ automatically even if the code inside the `do` scope throws an error.)
 Conversely, `load(::Stream)` and `save(::Stream)` should not close the
 input stream.
 
-`loadstreaming` and `savestreaming` use the same query mechanism, but return a decoded stream that users can `read` or `write`. You should also implement a `close` method on your reader or writer type. Just like with `load` and `save`, if the user provided a filename, your `close` method should be responsible for closing any streams you opened in order to read or write the file. If you are given a `Stream`, your `close` method should only do the clean up for your reader or writer type, not close the stream.
+`loadstreaming` and `savestreaming` use the same query mechanism, but return a
+decoded stream that users can `read` or `write`. You should also implement a
+`close` method on your reader or writer type. Just like with `load` and `save`,
+if the user provided a filename, your `close` method should be responsible for
+closing any streams you opened in order to read or write the file. If you are
+given a `Stream`, your `close` method should only do the clean up for your
+reader or writer type, not close the stream.
 
 ```julia
 struct WAVReader

--- a/README.md
+++ b/README.md
@@ -37,6 +37,40 @@ s = query(io)   # io is a stream
 will return a `File` or `Stream` object that also encodes the detected
 file format.
 
+Sometimes you want to read or write files that are larger than your available
+memory, or might be an unknown or infinite length (e.g. reading an audio or
+video stream from a socket). In these cases it might not make sense to process
+the whole file at once, but instead process it a chunk at a time. For these situations FileIO provides the `loadstreaming` and `savestreaming` functions, which return an object that you can `read` or `write`, rather than the file data itself.
+
+This would look something like:
+
+```jl
+using FileIO
+audio = loadstreaming("bigfile.wav")
+try
+    while !eof(audio)
+        chunk = read(audio, 4096) # read 4096 frames
+        # process the chunk
+    end
+finally
+    close(stream)
+end
+```
+
+or use `do` syntax to auto-close the stream:
+
+```jl
+using FileIO
+do loadstreaming("bigfile.wav") audio
+    while !eof(audio)
+        chunk = read(audio, 4096) # read 4096 frames
+        # process the chunk
+    end
+end
+```
+
+Note that in these cases you may want to use `read!` with a pre-allocated buffer for maximum efficiency.
+
 ## Adding new formats
 
 You register a new format by adding `add_format(fmt, magic,
@@ -138,6 +172,46 @@ they open.  (If you use the `do` syntax, this happens for you
 automatically even if the code inside the `do` scope throws an error.)
 Conversely, `load(::Stream)` and `save(::Stream)` should not close the
 input stream.
+
+`loadstreaming` and `savestreaming` use the same query mechanism, but return a decoded stream that users can `read` or `write`. You should also implement a `close` method on your reader or writer type. Just like with `load` and `save`, if the user provided a filename, your `close` method should be responsible for closing any streams you opened in order to read or write the file. If you are given a `Stream`, your `close` method should only do the clean up for your reader or writer type, not close the stream.
+
+```julia
+struct WAVReader
+    io::IO
+    ownstream::Bool
+end
+
+function read(reader::WAVReader, frames::Int)
+    # read and decode audio samples from reader.io
+end
+
+function close(reader::WAVReader)
+    # do whatever cleanup the reader needs
+    if reader.ownstream
+        close(reader.io)
+    end
+end
+loadstreaming(f::File{format"WAV"}) = WAVReader(open(f), ownstream=true)
+loadstreaming(s::Stream{format"WAV"}) = WAVReader(s, ownstream=false)
+# FileIO has fallback functions that make these work using `do` syntax as well.
+```
+
+If you choose to implement `loadstreaming` and `savestreaming` in your package,
+you can easily add `save` and `load` methods in the form of:
+
+```julia
+function save(q::Formatted{format"WAV"}, data, args...; kwargs...)
+    savestreaming(args...; kwargs...) do stream
+        write(stream, data)
+    end
+end
+
+function load(q::Formatted{format"WAV"}, args...; kwargs...)
+    savestreaming(args...; kwargs...) do stream
+        readall(stream)
+    end
+end
+```
 
 ## Help
 

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -42,9 +42,9 @@ include("registry.jl")
 
 - `load([filename|stream])`: read data in formatted file, inferring the format
 - `load(File(format"PNG",filename))`: specify the format manually
-- `loadstreaming(f)`: similar to `load`, except that it returns an object that can be read from
+- `loadstreaming([filename|stream])`: similar to `load`, except that it returns an object that can be read from
 - `save(filename, data...)` for similar operations involving saving data
-- `savestreaming(f)`: similar to `save`, except that it returns an object that can be written to
+- `savestreaming([filename|stream])`: similar to `save`, except that it returns an object that can be written to
 
 - `io = open(f::File, args...)` opens a file
 - `io = stream(s::Stream)` returns the IOStream from the query object `s`

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -17,9 +17,11 @@ export DataFormat,
        file_extension,
        info,
        load,
+       loadstreaming,
        magic,
        query,
        save,
+       savestreaming,
        skipmagic,
        stream,
        unknown
@@ -40,7 +42,9 @@ include("registry.jl")
 
 - `load([filename|stream])`: read data in formatted file, inferring the format
 - `load(File(format"PNG",filename))`: specify the format manually
+- `loadstreaming(f)`: similar to `load`, except that it returns an object that can be read from
 - `save(filename, data...)` for similar operations involving saving data
+- `savestreaming(f)`: similar to `save`, except that it returns an object that can be written to
 
 - `io = open(f::File, args...)` opens a file
 - `io = stream(s::Stream)` returns the IOStream from the query object `s`

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -44,8 +44,10 @@ add_saver
 - `load(filename)` loads the contents of a formatted file, trying to infer
 the format from `filename` and/or magic bytes in the file.
 - `load(strm)` loads from an `IOStream` or similar object. In this case,
-the magic bytes are essential.
-- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
+there is no filename extension, so we rely on the magic bytes for format
+identification.
+- `load(File(format"PNG", filename))` specifies the format directly, and bypasses inference.
+- `load(Stream(format"PNG", io))` specifies the format directly, and bypasses inference.
 - `load(f; options...)` passes keyword arguments on to the loader.
 """
 load
@@ -60,10 +62,14 @@ video or audio.
 the format from `filename` and/or magic bytes in the file. It returns a streaming
 type that can be read from in chunks, rather than loading the whole contents all
 at once
-- `loadstreaming(strm)` loads the stream from an `IOStream` or similar object. In this case,
-the magic bytes are essential.
-- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
-- `load(f; options...)` passes keyword arguments on to the loader.
+- `loadstreaming(strm)` loads the stream from an `IOStream` or similar object.
+In this case, there is no filename extension, so we rely on the magic bytes
+for format identification.
+- `loadstreaming(File(format"WAV",filename))` specifies the format directly, and
+bypasses inference.
+- `loadstreaming(Stream(format"WAV", io))` specifies the format directly, and
+bypasses inference.
+- `loadstreaming(f; options...)` passes keyword arguments on to the loader.
 """
 loadstreaming
 
@@ -71,6 +77,7 @@ loadstreaming
 - `save(filename, data...)` saves the contents of a formatted file,
 trying to infer the format from `filename`.
 - `save(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
+- `save(File(format"PNG",filename), data...)` specifies the format directly, and bypasses inference.
 - `save(f, data...; options...)` passes keyword arguments on to the saver.
 """
 save
@@ -82,7 +89,10 @@ accept formatted objects, like an image or chunk of video or audio.
 
 - `savestreaming(filename, data...)` saves the contents of a formatted file,
 trying to infer the format from `filename`.
-- `savestreaming(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
+- `savestreaming(File(format"WAV",filename))` specifies the format directly, and
+bypasses inference.
+- `savestreaming(Stream(format"WAV", io))` specifies the format directly, and
+bypasses inference.
 - `savestreaming(f, data...; options...)` passes keyword arguments on to the saver.
 """
 savestreaming

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -130,10 +130,12 @@ for fn in (:loadstreaming, :savestreaming)
     @eval function $fn(f::Function, args...; kwargs...)
         str = $fn(args...; kwargs...)
         try
-            f(str)
+            ret = f(str)
         finally
             close(str)
         end
+
+        ret
     end
 end
 

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -41,57 +41,9 @@ add_loader
 add_saver
 
 
-"""
-- `load(filename)` loads the contents of a formatted file, trying to infer
-the format from `filename` and/or magic bytes in the file.
-- `load(strm)` loads from an `IOStream` or similar object. In this case,
-the magic bytes are essential.
-- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
-- `load(f; options...)` passes keyword arguments on to the loader.
-"""
-load
-
-"""
-Some packages may implement a streaming API, where the contents of the file can
-be read in chunks and processed, rather than all at once. Reading from these
-higher-level streams should return a formatted object, like an image or chunk of
-video or audio.
-
-- `loadstreaming(filename)` loads the contents of a formatted file, trying to infer
-the format from `filename` and/or magic bytes in the file. It returns a streaming
-type that can be read from in chunks, rather than loading the whole contents all
-at once
-- `loadstreaming(strm)` loads the stream from an `IOStream` or similar object. In this case,
-the magic bytes are essential.
-- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
-- `load(f; options...)` passes keyword arguments on to the loader.
-"""
-loadstreaming
-
-"""
-- `save(filename, data...)` saves the contents of a formatted file,
-trying to infer the format from `filename`.
-- `save(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
-- `save(f, data...; options...)` passes keyword arguments on to the saver.
-"""
-save
-
-"""
-Some packages may implement a streaming API, where the contents of the file can
-be written in chunks, rather than all at once. These higher-level streams should
-accept formatted objects, like an image or chunk of video or audio.
-
-- `savestreaming(filename, data...)` saves the contents of a formatted file,
-trying to infer the format from `filename`.
-- `savestreaming(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
-- `savestreaming(f, data...; options...)` passes keyword arguments on to the saver.
-"""
-savestreaming
-
-
 for fn in (:load, :loadstreaming, :save, :savestreaming)
-    @eval $fn(s::Union{AbstractString,IO}, data...; options...) =
-        $fn(query(s), data...; options...)
+    @eval $fn(s::@compat(Union{AbstractString,IO}), args...; options...) =
+        $fn(query(s), args...; options...)
 end
 
 function save(s::Union{AbstractString,IO}; options...)
@@ -139,7 +91,6 @@ for fn in (:loadstreaming, :savestreaming)
     end
 end
 
-
 # Fallbacks
 for fn in (:load, :loadstreaming)
     @eval function $fn{F}(q::Formatted{F}, args...; options...)
@@ -182,6 +133,53 @@ for fn in (:save, :savestreaming)
         handle_exceptions(failures, "saving \"$(filename(q))\"")
     end
 end
+
+"""
+- `load(filename)` loads the contents of a formatted file, trying to infer
+the format from `filename` and/or magic bytes in the file.
+- `load(strm)` loads from an `IOStream` or similar object. In this case,
+the magic bytes are essential.
+- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
+- `load(f; options...)` passes keyword arguments on to the loader.
+"""
+load
+
+"""
+Some packages may implement a streaming API, where the contents of the file can
+be read in chunks and processed, rather than all at once. Reading from these
+higher-level streams should return a formatted object, like an image or chunk of
+video or audio.
+
+- `loadstreaming(filename)` loads the contents of a formatted file, trying to infer
+the format from `filename` and/or magic bytes in the file. It returns a streaming
+type that can be read from in chunks, rather than loading the whole contents all
+at once
+- `loadstreaming(strm)` loads the stream from an `IOStream` or similar object. In this case,
+the magic bytes are essential.
+- `load(File(format"PNG",filename))` specifies the format directly, and bypasses inference.
+- `load(f; options...)` passes keyword arguments on to the loader.
+"""
+loadstreaming
+
+"""
+- `save(filename, data...)` saves the contents of a formatted file,
+trying to infer the format from `filename`.
+- `save(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
+- `save(f, data...; options...)` passes keyword arguments on to the saver.
+"""
+save
+
+"""
+Some packages may implement a streaming API, where the contents of the file can
+be written in chunks, rather than all at once. These higher-level streams should
+accept formatted objects, like an image or chunk of video or audio.
+
+- `savestreaming(filename, data...)` saves the contents of a formatted file,
+trying to infer the format from `filename`.
+- `savestreaming(Stream(format"PNG",io), data...)` specifies the format directly, and bypasses inference.
+- `savestreaming(f, data...; options...)` passes keyword arguments on to the saver.
+"""
+savestreaming
 
 function has_method_from(mt, Library)
     for m in mt

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -61,15 +61,76 @@ module Dummy
 
 using FileIO
 
-function load(file::File{format"DUMMY"})
+mutable struct DummyReader{IOtype}
+    stream::IOtype
+    ownstream::Bool
+    bytesleft::Int64
+end
+
+function DummyReader(stream, ownstream)
+    read(stream, 5) == magic(format"DUMMY") || error("wrong magic bytes")
+    DummyReader(stream, ownstream, read(stream, Int64))
+end
+
+function Base.read(stream::DummyReader, n)
+    toread = min(n, stream.bytesleft)
+    buf = read(stream.stream, toread)
+    stream.bytesleft -= length(buf)
+    buf
+end
+
+Base.eof(stream::DummyReader) = stream.bytesleft == 0 || eof(stream.stream)
+Base.close(stream::DummyReader) = stream.ownstream && close(stream.stream)
+
+mutable struct DummyWriter{IOtype}
+    stream::IOtype
+    ownstream::Bool
+    headerpos::Int
+    byteswritten::Int
+end
+
+function DummyWriter(stream, ownstream)
+    write(stream, magic(format"DUMMY"))  # Write the magic bytes
+    # store the position where we'll need to write the length
+    pos = position(stream)
+    # write a dummy length value
+    write(stream, 0xffffffffffffffff)
+    DummyWriter(stream, ownstream, pos, 0)
+end
+
+function Base.write(stream::DummyWriter, data)
+    udata = convert(Vector{UInt8}, data)
+    n = write(stream.stream, udata)
+    stream.byteswritten += n
+
+    n
+end
+
+function Base.close(stream::DummyWriter)
+    here = position(stream.stream)
+    # go back and write the header
+    seek(stream.stream, stream.headerpos)
+    write(stream.stream, convert(Int64, stream.byteswritten))
+    seek(stream.stream, here)
+    stream.ownstream && close(stream.stream)
+
+    nothing
+end
+
+loadstreaming(s::Stream{format"DUMMY"}) = DummyReader(s, false)
+loadstreaming(file::File{format"DUMMY"}) = DummyReader(open(file), true)
+savestreaming(s::Stream{format"DUMMY"}) = DummyWriter(s, false)
+savestreaming(file::File{format"DUMMY"}) = DummyWriter(open(file, "w"), true)
+
+# we could implement `load` and `save` in terms of their streaming versions
+function FileIO.load(file::File{format"DUMMY"})
     open(file) do s
-        skipmagic(s)
         load(s)
     end
 end
 
-function load(s::Stream{format"DUMMY"})
-    # We're already past the magic bytes
+function FileIO.load(s::Stream{format"DUMMY"})
+    skipmagic(s)
     n = read(s, Int64)
     out = Vector{UInt8}(n)
     read!(s, out)
@@ -133,7 +194,6 @@ add_saver(format"DUMMY", :Dummy)
     @test a == b
 
     b = open(query(fn)) do s
-        skipmagic(s)
         load(s)
     end
     @test a == b

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -230,6 +230,14 @@ add_saver(format"DUMMY", :Dummy)
     @test load(fn) == a
     rm(fn)
 
+    # force format
+    fn = string(tempname(), ".dmy")
+    savestreaming(format"DUMMY", fn) do writer
+        write(writer, a)
+    end
+    @test load(fn) == a
+    rm(fn)
+
     # streaming I/O with streams
     save(fn, a)
     open(fn) do io

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -85,7 +85,7 @@ Base.close(stream::DummyReader) = stream.ownstream && close(stream.stream)
 mutable struct DummyWriter{IOtype}
     stream::IOtype
     ownstream::Bool
-    headerpos::Int
+    headerpos::Int64
     byteswritten::Int
 end
 


### PR DESCRIPTION
I figured it would be easier to discuss #77 if we had some code to look at. This PR is not close to mergeable, it's mostly to play with how this might work and get some feedback from you guys on whether you think this is a promising direction.

Here's the context (copied from the issue):

IIUC load and save are generally one-off operations, i.e. load("somefile.wav") loads the full wave file into memory.

Sometimes though, you have huge files that you might not want to load into memory all at once, or streams that have no end (like an internet radio stream). In my LibSndFile package I also export loadstream and savestream functions that instead return special stream types that you can read/write chunks of audio from.

@jongwook's MP3 package also has the same functionality, but it's not clear who should own those functions. It seems like it would make sense to have them in FileIO as they use all the same query tooling. In fact, we implement load and save as wrappers around the streaming versions.

Do these functions seem like they could fit into the FileIO architecture? What are the video packages currently doing for this sort of thing?
