### PR TITLE
Fix stack overflow when load/save are missing

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -8,7 +8,7 @@ immutable LoaderError <: Exception
     msg::Compat.UTF8String
 end
 Base.showerror(io::IO, e::LoaderError) = println(io, e.library, " load error: ",
-                                                 msg, "\n  Will try next loader.")
+                                                 e.msg, "\n  Will try next loader.")
 
 """
 `WriterError` should be thrown when writer library code fails, and other libraries should
@@ -21,7 +21,7 @@ immutable WriterError <: Exception
 end
 Base.showerror(io::IO, e::WriterError) = println(
     io, e.library, " writer error: ",
-    msg, "\n  Will try next writer."
+    e.msg, "\n  Will try next writer."
 )
 
 """

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -79,6 +79,9 @@ function load{F}(q::Formatted{F}, args...; options...)
     for library in libraries
         try
             Library = checked_import(library)
+            if !isdefined(Library, :load) || Library.load == FileIO.load
+                throw(LoaderError(string(library), "load not defined"))
+            end
             return Library.load(q, args...; options...)
         catch e
             handle_current_error(e, library, library == last(libraries))
@@ -94,6 +97,9 @@ function save{F}(q::Formatted{F}, data...; options...)
     for library in libraries
         try
             Library = checked_import(library)
+            if !isdefined(Library, :save) || Library.save == FileIO.save
+                throw(WriterError(string(library), "save not defined"))
+            end
             return Library.save(q, data...; options...)
         catch e
             handle_current_error(e, library, library == last(libraries))

--- a/test/error_handling.jl
+++ b/test/error_handling.jl
@@ -26,3 +26,18 @@ context("Not installed") do
 	eval(Base, :(is_interactive = false)) # for interactive error handling
 
 end
+
+
+# Missing load/save functions
+module BrokenIO
+using FileIO
+end
+add_format(format"BROKEN", (), ".brok", [:BrokenIO])
+
+context("Absent implementation") do
+    stderr_copy = STDERR
+    rserr, wrerr = redirect_stderr()
+    @fact_throws FileIO.LoaderError load(Stream(format"BROKEN", STDIN))
+    @fact_throws FileIO.WriterError save(Stream(format"BROKEN", STDOUT))
+    redirect_stderr(stderr_copy)
+end


### PR DESCRIPTION
On master, the following leads to a stack overflow:
```jl
julia> using FileIO

julia> module BrokenIO
       using FileIO
       end
BrokenIO

julia> add_format(format"BROKEN", (), ".brok", [:BrokenIO])
FileIO.DataFormat{:BROKEN}

julia> load(Stream(format"BROKEN", STDIN))
```
This arises because `FileIO` exports `load`, and since `BrokenIO` doesn't define its own internal `load`, `BrokenIO.load` just expands to `FileIO.load`. So `FileIO.load` ends up calling itself recursively. Moreover, because of the (unavoidable) type instability in `FileIO.load`, it's a very slow stack overflow to resolve, so it effectively results in a hang.

Now, one solution would be to recommend that packages do this:
```jl
import FileIO
using FileIO: File, Stream, @format_str
```
instead of `using FileIO`. But I believe it's more robust to take the route I've taken in this PR (for one thing, it will catch any preexisting packages without modification).
