### PR TITLE
Store the absolute path when querying or opening a Stream

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -279,7 +279,10 @@ function file!{F}(strm::Stream{F})
 end
 
 # Implement standard I/O operations for File and Stream
-@inline Base.open(file::File, args...) = Stream(file, open(filename(file), args...))
+@inline function Base.open{F<:DataFormat}(file::File{F}, args...)
+    fn = filename(file)
+    Stream(F, open(fn, args...), abspath(fn))
+end
 Base.close(s::Stream) = close(stream(s))
 
 Base.position(s::Stream) = position(stream(s))
@@ -369,7 +372,7 @@ function query(filename::AbstractString)
     end
     !isfile(filename) && return File{unknown_df}(filename) # (no extension || no magic byte) && no file
     # Otherwise, check the magic bytes
-    file!(query(open(filename), filename))
+    file!(query(open(filename), abspath(filename)))
 end
 
 lensym(s::Symbol) = 1

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -92,6 +92,21 @@ context("Save") do
     fn = string(tempname(), ".dmy")
     save(fn, a)
 
+    # Test for absolute paths
+    cd(dirname(fn)) do
+        fnrel = basename(fn)
+        f = query(fnrel)
+        @fact isabspath(filename(f)) --> true
+        @fact endswith(filename(f), fn) --> true # TravisOSX prepends "/private"
+        f = File(format"DUMMY", fnrel)
+        @fact isabspath(filename(f)) --> false
+        open(f) do s
+            @fact isabspath(get(filename(s))) --> true
+            @fact endswith(get(filename(s)), fn) --> true
+        end
+    end
+
+    # Test IO
     b = load(query(fn))
     @fact a --> b
 


### PR DESCRIPTION
If this seems desirable, perhaps don't hit the merge button just yet. This is technically breaking, so we might want to first merge other queued PRs, tag a version, merge this, and then tag a minor version bump.
