### PR TITLE
An alternative solution to the "missing method" problem

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -79,7 +79,7 @@ function load{F}(q::Formatted{F}, args...; options...)
     for library in libraries
         try
             Library = checked_import(library)
-            if !isdefined(Library, :load) || Library.load == FileIO.load
+            if !has_method_from(methods(Library.load), Library)
                 throw(LoaderError(string(library), "load not defined"))
             end
             return Library.load(q, args...; options...)
@@ -96,7 +96,7 @@ function save{F}(q::Formatted{F}, data...; options...)
     for library in libraries
         try
             Library = checked_import(library)
-            if !isdefined(Library, :save) || Library.save == FileIO.save
+            if !has_method_from(methods(Library.save), Library)
                 throw(WriterError(string(library), "save not defined"))
             end
             return Library.save(q, data...; options...)
@@ -105,4 +105,19 @@ function save{F}(q::Formatted{F}, data...; options...)
         end
     end
     handle_exceptions(failures, "saving \"$(filename(q))\"")
+end
+
+function has_method_from(mt, Library)
+    for m in mt
+        if getmodule(m) == Library
+            return true
+        end
+    end
+    false
+end
+
+if VERSION < v"0.5.0-dev+3543"
+    getmodule(m) = m.func.code.module
+else
+    getmodule(m) = m.module
 end


### PR DESCRIPTION
See https://github.com/JuliaLang/METADATA.jl/pull/6619#issuecomment-251478364

This one relies on checking the module in which each method was defined. I worry this could be slow if the registry gets big and lots of modules (inadvisedly) extend load/save. On the other hand I can understand why legacy packages (EDIT: meaning, ones that existed before FileIO was around) are reluctant to stop exporting `load/save` and force their users to say `using FileIO`.

I am not sure how I feel about this, but on balance I suspect we should go this route.

CC @alyst 