### PR TITLE
Modified magic number testing for PCX image files.

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -37,7 +37,6 @@ add_format(format"HDR", UInt8[0x23,0x3f,0x52,0x41,0x44,0x49,0x41,0x4e], ".hdr", 
 add_format(format"ICO", UInt8[0x00,0x00,0x01,0x00],                     ".ico", [:ImageMagick])
 add_format(format"INFO", UInt8[0x7a,0x62,0x65,0x78],                    ".info",[:ImageMagick])
 add_format(format"JP2", UInt8[0x00,0x00,0x00,0x0c,0x6a,0x50,0x20,0x20], ".jp2", [:ImageMagick])
-add_format(format"PCX", UInt8[0x0a,0x05,0x01,0x01],                     ".pcx", [:ImageMagick])
 add_format(format"PDB", UInt8[0x73,0x7a,0x65,0x7a],                     ".pdb", [:ImageMagick])
 add_format(format"PDF", UInt8[0x25,0x50,0x44,0x46],                     ".pdf", [:ImageMagick])
 add_format(format"PGM", UInt8[0x50,0x35,0x0a],                          ".pgm", [:ImageMagick])
@@ -87,6 +86,12 @@ add_format(
     UInt8[0x42,0x4d],
     ".bmp",
     [:QuartzImageIO, OSX],
+    [:ImageMagick]
+)
+add_format(
+    format"PCX",
+    (UInt8[0x0a,0x02], UInt8[0x0a,0x05]),
+    ".pcx",
     [:ImageMagick]
 )
 


### PR DESCRIPTION
The magic numbers now match the magic numbers used by
ImageMagick. Some valid PCX files are still not identified
correctly. This addresses https://github.com/JuliaIO/FileIO.jl/issues/90.