### PR TITLE
Add save method that returns function that acceps data

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -54,6 +54,10 @@ trying to infer the format from `filename`.
 save(s::Union{AbstractString,IO}, data...; options...) =
     save(query(s), data...; options...)
 
+function save(s::@compat(Union{AbstractString,IO}); options...)
+    data -> save(s, data; options...)
+end
+
 # Forced format
 function save{sym}(df::Type{DataFormat{sym}}, f::AbstractString, data...; options...)
     libraries = applicable_savers(df)

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -54,7 +54,7 @@ trying to infer the format from `filename`.
 save(s::Union{AbstractString,IO}, data...; options...) =
     save(query(s), data...; options...)
 
-function save(s::@compat(Union{AbstractString,IO}); options...)
+function save(Union{AbstractString,IO}; options...)
     data -> save(s, data; options...)
 end
 

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -54,7 +54,7 @@ trying to infer the format from `filename`.
 save(s::Union{AbstractString,IO}, data...; options...) =
     save(query(s), data...; options...)
 
-function save(Union{AbstractString,IO}; options...)
+function save(s::Union{AbstractString,IO}; options...)
     data -> save(s, data; options...)
 end
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -111,6 +111,23 @@ add_saver(format"DUMMY", :Dummy)
         end
     end
 
+    fn2 = string(tempname(), ".dmy")
+    a |> save(fn2)
+
+    # Test for absolute paths
+    cd(dirname(fn2)) do
+        fnrel = basename(fn2)
+        f = query(fnrel)
+        @test isabspath(filename(f))
+        @test endswith(filename(f),fn2) # TravisOSX prepends "/private"
+        f = File(format"DUMMY", fnrel)
+        @test !(isabspath(filename(f)))
+        open(f) do s
+            @test isabspath(get(filename(s)))
+            @test endswith(get(filename(s)),fn2)
+        end
+    end    
+
     # Test IO
     b = load(query(fn))
     @test a == b


### PR DESCRIPTION
This enables the following syntax:
````julia
something_you_want_to_save |> save("filename.ext")
````
I have *a lot* of follow up work on this in the pipeline that will enable some really cool data pipeline stuff, and it would be great if this could be merged and tagged soonish because I hope to get everything ready in time for my juliacon talk.

Once everything is in place, you'll be able to do things like this:
````julia
load("test.csv") |> @query(i, begin
    @where i.age>30
    @select {i.Name, i.Age}
end) |> save("test2.feather")
````
The follow up PRs will be support for CSV, Feather, Excel, SPSS, SAS and Stata files, all integrated with [IterableTables.jl](https://github.com/davidanthoff/IterableTables.jl) and [Query.jl](https://github.com/davidanthoff/Query.jl).