### PR TITLE
Register CSV, Feather, Excel and various stats formats

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -16,6 +16,13 @@ end
 
 add_format(format"RData", detect_rdata, [".rda", ".RData", ".rdata"], [:RData, LOAD])
 
+add_format(format"CSV", (), [".csv"], [:CSVFiles])
+add_format(format"Feather", (), [".feather"], [:FeatherFiles])
+add_format(format"Excel", (), [".xls", ".xlsx"], [:ExcelFiles, LOAD])
+add_format(format"Stata", (), [".dta"], [:StatFiles, LOAD])
+add_format(format"SPSS", (), [".sav", ".por"], [:StatFiles, LOAD])
+add_format(format"SAS", (), [".sas7bdat"], [:StatFiles, LOAD])
+
 # Image formats
 add_format(format"PBMBinary", b"P4", ".pbm", [:ImageMagick])
 add_format(format"PGMBinary", b"P5", ".pgm", [:Netpbm])


### PR DESCRIPTION
I'm about to register those four packages in METADATA.jl. There is a bit of a chicken and egg situation here: the tests in those four packages can only pass once this here is merged and tagged, but this here obviously only works if those four packages are registered.

Maybe the following would work: could this be merged onto ``master`` now, but not yet tagged? I'll then modify the CI builds for the four packages so that they run off the FileIO master branch. That should make those tests pass, then we can tag a new version of FileIO?

@SimonDanisch & @timholy again, thanks for helping me out with this!