### PR TITLE
Fix some save calls in the tests

### DIFF
--- a/test/error_handling.jl
+++ b/test/error_handling.jl
@@ -7,10 +7,10 @@ println("these tests will print warnings: ")
     stderr_copy = STDERR
     rs, wr = redirect_stdin()
     rserr, wrerr = redirect_stderr()
-    ref = @async save("test.not_installed")
+    ref = @async save("test.not_installed", nothing)
     println(wr, "y")
     @test_throws CompositeException wait(ref) #("unknown package NotInstalled")
-    ref = @async save("test.not_installed")
+    ref = @async save("test.not_installed", nothing)
     println(wr, "invalid") #test invalid input
     println(wr, "n") # don't install
     wait(ref)
@@ -35,7 +35,7 @@ add_format(format"BROKEN", (), ".brok", [:BrokenIO])
     stderr_copy = STDERR
     rserr, wrerr = redirect_stderr()
     @test_throws FileIO.LoaderError load(Stream(format"BROKEN",STDIN))
-    @test_throws FileIO.WriterError save(Stream(format"BROKEN",STDOUT))
+    @test_throws FileIO.WriterError save(Stream(format"BROKEN",STDOUT), nothing)
     redirect_stderr(stderr_copy)
     close(rserr);close(wrerr)
 end

--- a/test/query.jl
+++ b/test/query.jl
@@ -34,7 +34,7 @@ module LoadTest1
 import FileIO: @format_str, File
 load(file::File{format"MultiLib"}) = error()
 
-save(file::File{format"MultiLib"}) = open(file, "w") do s
+save(file::File{format"MultiLib"}, data) = open(file, "w") do s
     write(s, magic(format"MultiLib"))  # Write the magic bytes
     write(s, 0)
 end
@@ -44,7 +44,7 @@ module LoadTest2
 import FileIO: @format_str, File, magic
 load(file::File{format"MultiLib"}) = 42
 
-save(file::File{format"MultiLib"}) = open(file, "w") do s
+save(file::File{format"MultiLib"}, data) = open(file, "w") do s
     write(s, magic(format"MultiLib"))  # Write the magic bytes
     write(s, 42)
 end
@@ -244,7 +244,7 @@ try
         @test length(FileIO.sym2loader[:MultiLib]) == 2
         @test length(FileIO.sym2saver[:MultiLib]) == 1
         fn = string(tempname(), ".mlb")
-        save(fn)
+        save(fn, nothing)
         x = load(fn)
         open(query(fn), "r") do io
             skipmagic(io)


### PR DESCRIPTION
This fixes some bugs that were introduced in #123.

In particular, there were a number of tests that used a ``save`` method with only a filename, and that collides with the stuff in #123. I think at the end of the day those test cases were artificial and can easily be changed like in this PR.