### PR TITLE
Add .gitattributes to fix line ending of rda test file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/files/minimal_ascii.rda eol=lf


### PR DESCRIPTION
This fixes another test bug on Windows: if git is configured with the auto line ending setting, it will checkout the rda test file with CRLF line endings, and that breaks one of the tests. This setting makes sure that this file always has LR line endings. This bug didn't show up on appveyor because it uses a different git setting.