### PR TITLE
Add module to `isdefined` calls

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -2,7 +2,7 @@ const sym2loader = Dict{Symbol,Vector{Symbol}}()
 const sym2saver  = Dict{Symbol,Vector{Symbol}}()
 
 function is_installed(pkg::Symbol)
-    isdefined(pkg) && isa(getfield(Main, pkg), Module) && return true # is a module defined in Main scope
+    isdefined(Main, pkg) && isa(getfield(Main, pkg), Module) && return true # is a module defined in Main scope
     path = Base.find_in_path(string(pkg)) # hacky way to determine if a Package is installed
     path == nothing && return false
     return isfile(path)

--- a/test/query.jl
+++ b/test/query.jl
@@ -251,7 +251,7 @@ try
             a = read(io, Int)
             @test a == 42 #make sure that LoadTest2 is used for saving, even though its at position 2
         end
-        @test isdefined(:LoadTest1) # first module should load first but fail
+        @test isdefined(Main, :LoadTest1) # first module should load first but fail
         @test x == 42
         rm(fn)
     end


### PR DESCRIPTION
Fixes a depwarn on 0.7