### PR TITLE
Sd/fix137

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -21,7 +21,12 @@ for (applicable_, add_, dict_) in (
         (:applicable_loaders, :add_loader, :sym2loader),
         (:applicable_savers,  :add_saver,  :sym2saver))
     @eval begin
-        $applicable_{sym}(::Union{Type{DataFormat{sym}}, Formatted{DataFormat{sym}}}) = get($dict_, sym, [:FileIO]) # if no loader is declared, fallback to FileIO
+        function $applicable_{sym}(::Union{Type{DataFormat{sym}}, Formatted{DataFormat{sym}}})
+            if haskey($dict_, sym)
+                return $dict_[sym]
+            end
+            error("No $($applicable_) found for $(sym)")
+        end
         function $add_{sym}(::Type{DataFormat{sym}}, pkg::Symbol)
             list = get($dict_, sym, Symbol[])
             $dict_[sym] = push!(list, pkg)

--- a/test/query.jl
+++ b/test/query.jl
@@ -316,7 +316,8 @@ end
     open(q) do io
         @test position(io) == 0
         @test FileIO.detect_rdata(io)
-        @test position(io) == 5
+        # This will only be the case for /r/n line endings, which the sample file has
+        @test position(io) == 6
     end
 end
 @testset "Format with function for magic bytes" begin

--- a/test/query.jl
+++ b/test/query.jl
@@ -316,8 +316,8 @@ end
     open(q) do io
         @test position(io) == 0
         @test FileIO.detect_rdata(io)
-        # This will only be the case for /r/n line endings, which the sample file has
-        @test position(io) == 6
+        # 6 for /r/n  and 5 for /n
+        @test (position(io) in (5, 6))
     end
 end
 @testset "Format with function for magic bytes" begin


### PR DESCRIPTION
applicable savers shouldn't fall back to FileIO, since it will make save stack overflow for unkown formats.