### PR TITLE
Add JLD2 to data formats

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,7 +1,9 @@
 ### Simple cases
 
 # data formats
-add_format(format"JLD", "Julia data file (HDF5)", ".jld", [:JLD])
+add_format(format"JLD", (Vector{UInt8}("Julia data file (HDF5), version 0.0"),
+                         Vector{UInt8}("Julia data file (HDF5), version 0.1")), ".jld", [:JLD])
+add_format(format"JLD2", "Julia data file (HDF5), version 0.2", ".jld2", [:JLD2])
 add_format(format"GZIP", [0x1f, 0x8b], ".gz", [:Libz])
 
 # test for RD?2 magic sequence at the beginning of R data input stream


### PR DESCRIPTION
For now, I am registering the extension `.jld2` to avoid ambiguity with JLD when saving, although someday, after JLD2 receives some testing, we may want to reassign the `.jld` extension to JLD2.