### PR TITLE
Custom function to find bedgraph magic bytes (take 2)

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -29,8 +29,6 @@ add_format(format"SAS", UInt8[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0xcf, 0xbd, 0x92, 0x08, 0x00, 0x09, 0xc7, 0x31, 0x8c, 0x18, 0x1f,
     0x10, 0x11], [".sas7bdat"], [:StatFiles, LOAD])
 
-add_format(format"bedGraph", UInt8[0x74, 0x79, 0x70, 0x65, 0x3D, 0x62, 0x65, 0x64, 0x47, 0x72, 0x61, 0x70, 0x68], [".bedgraph"], [:BedgraphFiles])
-
 # Image formats
 add_format(format"PBMBinary", b"P4", ".pbm", [:ImageMagick])
 add_format(format"PGMBinary", b"P5", ".pgm", [:Netpbm])
@@ -149,6 +147,26 @@ add_format(format"FLAC","fLaC",".flac",[:FLAC])
 
 
 ### Complex cases
+
+# bedGraph: the complication is that the magic bytes may start at any location within an indeterminate header.
+const bedgraph_magic = UInt8[0x74, 0x79, 0x70, 0x65, 0x3D, 0x62, 0x65, 0x64, 0x47, 0x72, 0x61, 0x70, 0x68]
+function detect_bedgraph(io)
+    position(io) == 0 || return false
+
+    line = ""
+
+    # Check lines for magic bytes.
+    while !eof(io) && !ismatch(r"^(\S+)\s+(\d+)\s+(\d+)\s+(\S+)\n", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
+        line = readline(io,chomp=false)
+
+        if contains(line, bedgraph_magic) # if contains(line, "type=bedGraph")
+            return true
+        end
+    end
+
+    return false
+end
+add_format(format"bedGraph", detect_bedgraph, [".bedgraph"], [:BedgraphFiles])
 
 # Handle OME-TIFFs, which are identical to normal TIFFs with the primary difference being the filename and embedded XML metadata
 const tiff_magic = (UInt8[0x4d,0x4d,0x00,0x2a], UInt8[0x4d,0x4d,0x00,0x2b], UInt8[0x49,0x49,0x2a,0x00],UInt8[0x49,0x49,0x2b,0x00])

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -156,8 +156,8 @@ function detect_bedgraph(io)
     line = ""
 
     # Check lines for magic bytes.
-    while !eof(io) && !ismatch(r"^(\S+)\s+(\d+)\s+(\d+)\s+(\S+)\n", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
-        line = readline(io,chomp=false)
+    while !eof(io) && !ismatch(r"^\s*([A-Za-z]+\S*)\s+(\d+)\s+(\d+)\s+(\S*\d)\s*$", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
+        line = readline(io, chomp=false)
 
         if contains(line, String(bedgraph_magic)) # Note: String(bedgraph_magic) = "type=bedGraph"
             return true

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -159,7 +159,7 @@ function detect_bedgraph(io)
     while !eof(io) && !ismatch(r"^(\S+)\s+(\d+)\s+(\d+)\s+(\S+)\n", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
         line = readline(io,chomp=false)
 
-        if contains(line, bedgraph_magic) # if contains(line, "type=bedGraph")
+        if contains(line, String(bedgraph_magic)) # Note: String(bedgraph_magic) = "type=bedGraph"
             return true
         end
     end

--- a/test/files/file.bedgraph
+++ b/test/files/file.bedgraph
@@ -1,0 +1,18 @@
+browser position chr19:49302001-49304701
+browser hide all
+browser pack refGene encodeRegions
+browser full altGraph
+#	300 base wide bar graph, autoScale is on by default == graphing
+#	limits will dynamically change to always show full range of data
+#	in viewing window, priority = 20 positions this as the second graph
+#	Note, zero-relative, half-open coordinate system in use for bedGraph format
+track type=bedGraph name="BedGraph Format" description="BedGraph format" visibility=full color=200,100,0 altColor=0,100,200 priority=20
+chr19 49302000 49302300 -1.0
+chr19 49302300 49302600 -0.75
+chr19 49302600 49302900 -0.50
+chr19 49302900 49303200 -0.25
+chr19 49303200 49303500 0.0
+chr19 49303500 49303800 0.25
+chr19 49303800 49304100 0.50
+chr19 49304100 49304400 0.75
+chr19 49304400 49304700 1.00

--- a/test/query.jl
+++ b/test/query.jl
@@ -267,6 +267,19 @@ finally
 end
 
 file_dir = joinpath(dirname(@__FILE__), "files")
+@testset "bedGraph" begin
+    q = query(joinpath(file_dir, "file.bedgraph"))
+    @test typeof(q) == File{format"bedGraph"}
+    open(q) do io
+        @test position(io) == 0
+        skipmagic(io)
+        @test position(io) == 0 # no skipping for functions
+        # @test FileIO.detect_bedgraph(io) # MethodError: no method matching readline(::FileIO.Stream{FileIO.DataFormat{:bedGraph},IOStream}; chomp=false)
+    end
+    open(joinpath(file_dir, "file.bedgraph")) do io
+        @test (FileIO.detect_bedgraph(io))
+    end
+end
 @testset "STL detection" begin
     q = query(joinpath(file_dir, "ascii.stl"))
     @test typeof(q) == File{format"STL_ASCII"}


### PR DESCRIPTION
Sorry @timholy, I somehow closed #155 when tidying my develop branch.

This pull request additionally converts the magic bytes to a string for the use of the `contains(::AbstractString, ::AbstractString)` method.