### PR TITLE
WIP Add vega and vegalite spec support

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -283,3 +283,6 @@ add_format(format"FITS",
 add_format(format"RawArray", [0x61,0x72,0x61,0x77,0x72,0x72,0x79,0x61], ".ra", [:RawArray])
 
 add_format(format"MetaImage", "ObjectType", ".mhd", [:MetaImageFormat])
+
+add_format(format"vega", (), [".vega"], [:VegaCore])
+add_format(format"vegalite", (), [".vegalite"], [:VegaCore])


### PR DESCRIPTION
Again a not-yet-ready thing. In particular, I hope that these file extensions actually get adopted, right now they use ``.vl.json`` and ``vg.json``, both of which don't work with the system here because it only treats ``.json`` as the extension (rightly, I think).