### PR TITLE
1st pass at fixing v0.7 deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7.0-
 Compat 0.28.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.7.0-
 Compat 0.28.0
+Nullables

--- a/docs/make_docs.jl
+++ b/docs/make_docs.jl
@@ -16,10 +16,10 @@ extension2string(x) = join(map(string, x), ", ")
 extension2string(x::AbstractString) = x
 
 os2string(x::Vector) = isempty(x) ? "**all** platforms " : join(map(os2string, x), ", ")
-os2string{O <: OS}(os::Type{O}) = "**$(O.name.name)**"
+os2string(os::Type{O}) where {O <: OS} = "**$(O.name.name)**"
 
 magic2string(x::Function) = "has detection function"
-magic2string(x::Tuple) = isempty(x) ? "only extension": string(x)
+magic2string(x::Tuple) = isempty(x) ? "only extension" : string(x)
 magic2string(x) = string(x)
 function loadsave2string(load_save_libraries)
     io = IOBuffer()
@@ -38,23 +38,23 @@ function loadsave2string(load_save_libraries)
     end
     String(take!(io))
 end
-function add_format{Sym}(::Type{DataFormat{Sym}}, magic, extension, io_libs...)
+function add_format(::Type{DataFormat{Sym}}, magic, extension, io_libs...) where Sym
     println(fs, "| $(Sym) | $(extension2string(extension)) | $(loadsave2string(io_libs)) | $(magic2string(magic)) |")
 end
 
 
-function add_format{sym}(fmt::Type{DataFormat{sym}}, magic::Union{Tuple,AbstractVector,String}, extension)
+function add_format(fmt::Type{DataFormat{sym}}, magic::Union{Tuple,AbstractVector,String}, extension) where sym
     println(sym)
 end
 
 # for multiple magic bytes
-function add_format{sym, T <: Vector{UInt8}, N}(fmt::Type{DataFormat{sym}}, magics::NTuple{N, T}, extension)
+function add_format(fmt::Type{DataFormat{sym}}, magics::NTuple{N, T}, extension) where {sym, T <: Vector{UInt8}, N}
     println(sym)
 end
 
 # For when "magic" is supplied as a function (see the HDF5 example in
 # registry.jl)
-function add_format{sym}(fmt::Type{DataFormat{sym}}, magic, extension)
+function add_format(fmt::Type{DataFormat{sym}}, magic, extension) where sym
     println(sym)
 end
 

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module FileIO
 
-using Compat
+using Compat, Nullables, Pkg
 
 export DataFormat,
        File,

--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -60,7 +60,7 @@ Handles a list of thrown errors after no IO library was found working
 function handle_exceptions(exceptions::Vector, action)
     # first show all errors when there are more then one
     multiple = length(exceptions) > 1
-    println(STDERR, "Error$(multiple ? "s" : "") encountered while $action.")
+    println(stderr, "Error$(multiple ? "s" : "") encountered while $action.")
     if multiple
         println("All errors:")
         for (err, file) in exceptions
@@ -70,7 +70,7 @@ function handle_exceptions(exceptions::Vector, action)
     # then handle all errors.
     # this way first fatal exception throws and user can still see all errors
     # TODO, don't throw, if it contains a NotInstalledError?!
-    println(STDERR, "Fatal error:")
+    println(stderr, "Fatal error:")
     for exception in exceptions
         continue_ = handle_error(exception...)
         continue_ || break
@@ -84,13 +84,13 @@ function handle_error(e::NotInstalledError, q)
     !isinteractive() && rethrow(e) # if we're not in interactive mode just throw
     while true
         println("Should we install \"", e.library, "\" for you? (y/n):")
-        input = lowercase(chomp(strip(readline(STDIN))))
+        input = lowercase(chomp(strip(readline(stdin))))
         if input == "y"
-            info(string("Start installing ", e.library, "..."))
+            @info(string("Start installing ", e.library, "..."))
             Pkg.add(string(e.library))
             return false # don't continue
         elseif input == "n"
-            info(string("Not installing ", e.library))
+            @info(string("Not installing ", e.library))
             return true # User does not install, continue going through errors.
         else
             println("$input is not a valid choice. Try typing y or n")

--- a/src/mimesave.jl
+++ b/src/mimesave.jl
@@ -3,7 +3,7 @@ module MimeWriter
 using ..FileIO: File, @format_str
 
 function save(file::File{format"PNG"}, data)
-    if mimewritable("image/png", data)
+    if showable("image/png", data)
         open(file.filename, "w") do s
             show(IOContext(s, :full_fidelity=>true), "image/png", data)
         end
@@ -13,7 +13,7 @@ function save(file::File{format"PNG"}, data)
 end
 
 function save(file::File{format"SVG"}, data)
-    if mimewritable("image/svg+xml", data)
+    if showable("image/svg+xml", data)
         open(file.filename, "w") do s
             show(IOContext(s, :full_fidelity=>true), "image/svg+xml", data)
         end
@@ -23,7 +23,7 @@ function save(file::File{format"SVG"}, data)
 end
 
 function save(file::File{format"PDF"}, data)
-    if mimewritable("application/pdf", data)
+    if showable("application/pdf", data)
         open(file.filename, "w") do s
             show(IOContext(s, :full_fidelity=>true), "application/pdf", data)
         end
@@ -33,7 +33,7 @@ function save(file::File{format"PDF"}, data)
 end
 
 function save(file::File{format"EPS"}, data)
-    if mimewritable("application/eps", data)
+    if showable("application/eps", data)
         open(file.filename, "w") do s
             show(IOContext(s, :full_fidelity=>true), "application/eps", data)
         end

--- a/src/query.jl
+++ b/src/query.jl
@@ -151,7 +151,7 @@ function del_magic(magic::NTuple{N, UInt8}, sym) where N
 end
 
 function del_magic(magic::Function, sym)
-    deleteat!(magic_func, coalesce(findfirst(equalto(Pair(magic, sym)), magic_func), 0))
+    deleteat!(magic_func, coalesce(findfirst(isequal(Pair(magic, sym)), magic_func), 0))
     nothing
 end
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -52,9 +52,9 @@ unknown(::Type{format"UNKNOWN"})    = true
 unknown(::Type{DataFormat{sym}}) where {sym} = false
 
 const ext2sym    = Dict{String, Union{Symbol,Vector{Symbol}}}()
-const magic_list = Vector{Pair}(uninitialized, 0)    # sorted, see magic_cmp below
+const magic_list = Vector{Pair}(undef, 0)    # sorted, see magic_cmp below
 const sym2info   = Dict{Symbol,Any}()  # Symbol=>(magic, extension)
-const magic_func = Vector{Pair}(uninitialized, 0)    # for formats with complex magic #s
+const magic_func = Vector{Pair}(undef, 0)    # for formats with complex magic #s
 
 
 function add_format(fmt, magic, extension, load_save_libraries...)
@@ -399,7 +399,7 @@ format inferred from the magic bytes.
 query(io::IO, filename) = query(io, Nullable(String(filename)))
 
 function query(io::IO, filename::Nullable{String}=Nullable{String}())
-    magic = Vector{UInt8}(uninitialized, 0)
+    magic = Vector{UInt8}(undef, 0)
     pos = position(io)
     for p in magic_list
         m = first(p)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -146,10 +146,10 @@ add_format(format"GSLIB", (), [".gslib",".sgems"], [:GslibIO])
 ### Audio formats
 function detectwav(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(4))
+    magic = read!(io, Vector{UInt8}(uninitialized, 4))
     magic == b"RIFF" || return false
     seek(io, 8)
-    submagic = read!(io, Vector{UInt8}(4))
+    submagic = read!(io, Vector{UInt8}(uninitialized, 4))
 
     submagic == b"WAVE"
 end
@@ -167,8 +167,8 @@ function detect_bedgraph(io)
     line = ""
 
     # Check lines for magic bytes.
-    while !eof(io) && !ismatch(r"^\s*([A-Za-z]+\S*)\s+(\d+)\s+(\d+)\s+(\S*\d)\s*$", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
-        line = readline(io, chomp=false)
+    while !eof(io) && !contains(line, r"^\s*([A-Za-z]+\S*)\s+(\d+)\s+(\d+)\s+(\S*\d)\s*$") # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
+        line = readline(io, keep=true)
 
         if contains(line, String(bedgraph_magic)) # Note: String(bedgraph_magic) = "type=bedGraph"
             return true
@@ -183,7 +183,7 @@ add_format(format"bedGraph", detect_bedgraph, [".bedgraph"], [:BedgraphFiles])
 const tiff_magic = (UInt8[0x4d,0x4d,0x00,0x2a], UInt8[0x4d,0x4d,0x00,0x2b], UInt8[0x49,0x49,0x2a,0x00],UInt8[0x49,0x49,0x2b,0x00])
 function detecttiff(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(4))
+    magic = read!(io, Vector{UInt8}(uninitialized, 4))
     # do any of the first 4 bytes match any of the 4 possible combinations of tiff magics
     return any(map(x->all(magic .== x), tiff_magic))
 end
@@ -201,10 +201,10 @@ skipmagic(io, ::typeof(detect_noometiff)) = seek(io, 4)
 # AVI is a subtype of RIFF, as is WAV
 function detectavi(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(4))
+    magic = read!(io, Vector{UInt8}(uninitialized, 4))
     magic == b"RIFF" || return false
     seek(io, 8)
-    submagic = read!(io, Vector{UInt8}(4))
+    submagic = read!(io, Vector{UInt8}(uninitialized, 4))
 
     submagic == b"AVI "
 end
@@ -218,7 +218,7 @@ function detecthdf5(io)
     seekend(io)
     len = position(io)
     seekstart(io)
-    magic = Vector{UInt8}(length(h5magic))
+    magic = Vector{UInt8}(uninitialized, length(h5magic))
     pos = position(io)
     while pos+length(h5magic) <= len
         read!(io, magic)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -146,10 +146,10 @@ add_format(format"GSLIB", (), [".gslib",".sgems"], [:GslibIO])
 ### Audio formats
 function detectwav(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(uninitialized, 4))
+    magic = read!(io, Vector{UInt8}(undef, 4))
     magic == b"RIFF" || return false
     seek(io, 8)
-    submagic = read!(io, Vector{UInt8}(uninitialized, 4))
+    submagic = read!(io, Vector{UInt8}(undef, 4))
 
     submagic == b"WAVE"
 end
@@ -183,7 +183,7 @@ add_format(format"bedGraph", detect_bedgraph, [".bedgraph"], [:BedgraphFiles])
 const tiff_magic = (UInt8[0x4d,0x4d,0x00,0x2a], UInt8[0x4d,0x4d,0x00,0x2b], UInt8[0x49,0x49,0x2a,0x00],UInt8[0x49,0x49,0x2b,0x00])
 function detecttiff(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(uninitialized, 4))
+    magic = read!(io, Vector{UInt8}(undef, 4))
     # do any of the first 4 bytes match any of the 4 possible combinations of tiff magics
     return any(map(x->all(magic .== x), tiff_magic))
 end
@@ -201,10 +201,10 @@ skipmagic(io, ::typeof(detect_noometiff)) = seek(io, 4)
 # AVI is a subtype of RIFF, as is WAV
 function detectavi(io)
     seekstart(io)
-    magic = read!(io, Vector{UInt8}(uninitialized, 4))
+    magic = read!(io, Vector{UInt8}(undef, 4))
     magic == b"RIFF" || return false
     seek(io, 8)
-    submagic = read!(io, Vector{UInt8}(uninitialized, 4))
+    submagic = read!(io, Vector{UInt8}(undef, 4))
 
     submagic == b"AVI "
 end
@@ -218,7 +218,7 @@ function detecthdf5(io)
     seekend(io)
     len = position(io)
     seekstart(io)
-    magic = Vector{UInt8}(uninitialized, length(h5magic))
+    magic = Vector{UInt8}(undef, length(h5magic))
     pos = position(io)
     while pos+length(h5magic) <= len
         read!(io, magic)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -167,10 +167,10 @@ function detect_bedgraph(io)
     line = ""
 
     # Check lines for magic bytes.
-    while !eof(io) && !contains(line, r"^\s*([A-Za-z]+\S*)\s+(\d+)\s+(\d+)\s+(\S*\d)\s*$") # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
+    while !eof(io) && !occursin(r"^\s*([A-Za-z]+\S*)\s+(\d+)\s+(\d+)\s+(\S*\d)\s*$", line) # Note: regex is used to limit the search by exiting the loop when a line matches the bedGraph track format.
         line = readline(io, keep=true)
 
-        if contains(line, String(bedgraph_magic)) # Note: String(bedgraph_magic) = "type=bedGraph"
+        if occursin(String(bedgraph_magic), line) # Note: String(bedgraph_magic) = "type=bedGraph"
             return true
         end
     end

--- a/test/error_handling.jl
+++ b/test/error_handling.jl
@@ -1,19 +1,20 @@
-println("these tests will print warnings: ")
+@info("These tests will print warnings:")
+
 @testset "Not installed" begin
     eval(Base, :(is_interactive = true)) # for interactive error handling
 
     add_format(format"NotInstalled", (), ".not_installed", [:NotInstalled])
-    stdin_copy = STDIN
-    stderr_copy = STDERR
+    stdin_copy = stdin
+    stderr_copy = stderr
     rs, wr = redirect_stdin()
     rserr, wrerr = redirect_stderr()
     ref = @async save("test.not_installed", nothing)
     println(wr, "y")
-    @test_throws CompositeException wait(ref) #("unknown package NotInstalled")
+    @test_throws CompositeException fetch(ref) #("unknown package NotInstalled")
     ref = @async save("test.not_installed", nothing)
     println(wr, "invalid") #test invalid input
     println(wr, "n") # don't install
-    wait(ref)
+    fetch(ref)
     @test istaskdone(ref)
 
     close(rs);close(wr);close(rserr);close(wrerr)
@@ -32,10 +33,10 @@ end
 add_format(format"BROKEN", (), ".brok", [:BrokenIO])
 
 @testset "Absent implementation" begin
-    stderr_copy = STDERR
+    stderr_copy = stderr
     rserr, wrerr = redirect_stderr()
-    @test_throws FileIO.LoaderError load(Stream(format"BROKEN",STDIN))
-    @test_throws FileIO.WriterError save(Stream(format"BROKEN",STDOUT), nothing)
+    @test_throws FileIO.LoaderError load(Stream(format"BROKEN",stdin))
+    @test_throws FileIO.WriterError save(Stream(format"BROKEN",stdout), nothing)
     redirect_stderr(stderr_copy)
     close(rserr);close(wrerr)
 end
@@ -49,7 +50,7 @@ import FileIO: @format_str, File, magic
 load(file::File{format"MultiError"}) = error("2")
 end
 @testset "multiple errors" begin
-    println("this test will print warnings: ")
+    @info("This test will print warnings:")
     add_format(
         format"MultiError",
         (),

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -71,7 +71,7 @@ end
 function load(s::Stream{format"DUMMY"})
     # We're already past the magic bytes
     n = read(s, Int64)
-    out = Vector{UInt8}(uninitialized, n)
+    out = Vector{UInt8}(undef, n)
     read!(s, out)
     close(s)
     out

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -1,5 +1,5 @@
 using FileIO
-using Base.Test
+using Test
 
 # Stub readers---these might bork any existing readers, so don't
 # run these tests while doing other things!
@@ -18,7 +18,7 @@ sym2saver = copy(FileIO.sym2saver)
 try
     empty!(FileIO.sym2loader)
     empty!(FileIO.sym2saver)
-    file_dir = joinpath(dirname(@__FILE__), "files")
+    global file_dir = joinpath(dirname(@__FILE__), "files")
     @testset "Load" begin
 
         add_loader(format"PBMText", :TestLoadSave)
@@ -71,7 +71,7 @@ end
 function load(s::Stream{format"DUMMY"})
     # We're already past the magic bytes
     n = read(s, Int64)
-    out = Vector{UInt8}(n)
+    out = Vector{UInt8}(uninitialized, n)
     read!(s, out)
     close(s)
     out

--- a/test/query.jl
+++ b/test/query.jl
@@ -164,10 +164,12 @@ try
         @test typeof(q) == File{format"BAD"}
 
         # Unknown extension
-        fn = string("tempname", ".wrd")
+        fn = string("tempname", ".weird")
+
         open(fn, "w") do file
             write(file, "More data")
         end
+
         @test unknown(query(fn))
         rm(fn)
 

--- a/test/query.jl
+++ b/test/query.jl
@@ -164,7 +164,7 @@ try
         @test typeof(q) == File{format"BAD"}
 
         # Unknown extension
-        fn = string("tempname", ".weird")
+        fn = string("tempname", ".wrd")
 
         open(fn, "w") do file
             write(file, "More data")

--- a/test/query.jl
+++ b/test/query.jl
@@ -1,6 +1,9 @@
 using FileIO
-using Base.Test
+using Test
 using Compat
+using Nullables
+using Random
+using Pkg
 
 @testset "OS" begin
     if Compat.Sys.islinux()
@@ -266,7 +269,7 @@ finally
     merge!(FileIO.sym2info, sym2info)
 end
 
-file_dir = joinpath(dirname(@__FILE__), "files")
+global file_dir = joinpath(dirname(@__FILE__), "files")
 @testset "bedGraph" begin
     q = query(joinpath(file_dir, "file.bedgraph"))
     @test typeof(q) == File{format"bedGraph"}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using FileIO
-using Base.Test
+using Test
 
-immutable MimeSaveTestType
+struct MimeSaveTestType
 end
 
 @testset "FileIO" begin

--- a/test/test_mimesave.jl
+++ b/test/test_mimesave.jl
@@ -1,5 +1,5 @@
 using FileIO
-using Base.Test
+using Test
 
 @testset "Mime save" begin
 


### PR DESCRIPTION
This PR is an attempt to fix most of the deprecations and errors that you get when running the FileIO tests on v0.7.

These are the only two left which I couldn't track down:

```
julia> Pkg.test("FileIO")
WARNING: Base.Pkg is deprecated, run `using Pkg` instead
 in module Main
[ Info: Testing FileIO
┌ Warning: Vector{UInt8}(s::String) will copy data in the future. To avoid copying, use `unsafe_wrap` or `codeunits` instead.
│   caller = top-level scope
└ @ Core :0
┌ Warning: Vector{UInt8}(s::String) will copy data in the future. To avoid copying, use `unsafe_wrap` or `codeunits` instead.
│   caller = top-level scope
└ @ Core :0

```