### PR TITLE
add metadata(), to avoid loading the whole file

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -24,7 +24,8 @@ export DataFormat,
        savestreaming,
        skipmagic,
        stream,
-       unknown
+       unknown,
+       metadata
 
 import Base.showerror
 

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -99,7 +99,7 @@ savestreaming
 
 # if a bare filename or IO stream are given, query for the format and dispatch
 # to the formatted handlers below
-for fn in (:load, :loadstreaming, :save, :savestreaming)
+for fn in (:load, :loadstreaming, :save, :savestreaming, :metadata)
     @eval $fn(s::Union{AbstractString,IO}, args...; options...) =
         $fn(query(s), args...; options...)
 end
@@ -152,7 +152,7 @@ end
 
 # Handlers for formatted files/streams
 
-for fn in (:load, :loadstreaming)
+for fn in (:load, :loadstreaming, :metadata)
     @eval function $fn{F}(q::Formatted{F}, args...; options...)
         if unknown(q)
             isfile(filename(q)) || open(filename(q))  # force systemerror

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -129,6 +129,14 @@ function FileIO.load(file::File{format"DUMMY"})
     end
 end
 
+function FileIO.metadata(file::File{format"DUMMY"})
+    s = open(file)
+    skipmagic(s)
+    n = read(s, Int64)
+    close(s)
+    return n
+end
+
 function FileIO.load(s::Stream{format"DUMMY"})
     skipmagic(s)
     n = read(s, Int64)
@@ -156,6 +164,7 @@ add_saver(format"DUMMY", :Dummy)
     a = [0x01,0x02,0x03]
     fn = string(tempname(), ".dmy")
     save(fn, a)
+    @test metadata(fn) == 3
 
     # Test for absolute paths
     cd(dirname(fn)) do


### PR DESCRIPTION
closes https://github.com/JuliaIO/FileIO.jl/issues/173

also see https://github.com/JuliaImages/Images.jl/pull/714 and https://github.com/JuliaIO/ImageMagick.jl/pull/111