### PR TITLE
Add support for fileio_* names

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ Consequently, **packages should define "private" `load` and `save` methods (also
 `loadstreaming` and `savestreaming` if you implement them), and not extend
 (import) FileIO's**.
 
+If you run into a naming conflict with the `load` and `save` functions
+(for example, you already have another function in your package that has
+one of these names), you can instead name your loaders `fileio_load`, 
+`fileio_save` etc. Note that you cannot mix and match these styles: either
+all your loaders have to be named `load`, or all of them should be called
+`fileio_load`, but you cannot use both conventions in one module.
+
 `load(::File)` and `save(::File)` should close any streams
 they open.  (If you use the `do` syntax, this happens for you
 automatically even if the code inside the `do` scope throws an error.)

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -173,6 +173,10 @@ for fn in (:load, :loadstreaming, :metadata)
         for library in libraries
             try
                 Library = checked_import(library)
+                gen2_func_name = Symbol("fileio_" * $(string(fn)))
+                if isdefined(Library, gen2_func_name)
+                    return eval(Library, :($gen2_func_name($q, $args...; $options...)))
+                end
                 if !has_method_from(methods(Library.$fn), Library)
                     throw(LoaderError(string(library), "$($fn) not defined"))
                 end
@@ -193,6 +197,10 @@ for fn in (:save, :savestreaming)
         for library in libraries
             try
                 Library = checked_import(library)
+                gen2_func_name = Symbol("fileio_" * $(string(fn)))
+                if isdefined(Library, gen2_func_name)
+                    return eval(Library, :($gen2_func_name($q, $data...; $options...)))
+                end
                 if !has_method_from(methods(Library.$fn), Library)
                     throw(WriterError(string(library), "$($fn) not defined"))
                 end

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -7,9 +7,12 @@ module TestLoadSave
 import FileIO: File, @format_str
 load(file::File{format"PBMText"})   = "PBMText"
 load(file::File{format"PBMBinary"}) = "PBMBinary"
-load(file::File{format"HDF5"})      = "HDF5"
 load(file::File{format"JLD"})       = "JLD"
 load(file::File{format"GZIP"})       = "GZIP"
+end
+module TestLoadSave2
+import FileIO: File, @format_str
+fileio_load(file::File{format"HDF5"})      = "HDF5"
 end
 
 sym2loader = copy(FileIO.sym2loader)
@@ -23,7 +26,7 @@ try
 
         add_loader(format"PBMText", :TestLoadSave)
         add_loader(format"PBMBinary", :TestLoadSave)
-        add_loader(format"HDF5", :TestLoadSave)
+        add_loader(format"HDF5", :TestLoadSave2)
         add_loader(format"JLD", :TestLoadSave)
         add_loader(format"GZIP", :TestLoadSave)
 
@@ -285,12 +288,12 @@ load(f::File{format"AmbigExt2"}) = open(f) do io
     read(stream(io), String)
 end
 
-save(f::File{format"AmbigExt1"}, testdata) = open(f, "w") do io
+fileio_save(f::File{format"AmbigExt1"}, testdata) = open(f, "w") do io
     s = stream(io)
     print(s, "ambigext1")
     print(s, testdata)
 end
-save(f::File{format"AmbigExt2"}, testdata) = open(f, "w") do io
+fileio_save(f::File{format"AmbigExt2"}, testdata) = open(f, "w") do io
     s = stream(io)
     print(s, "ambigext2")
     print(s, testdata)


### PR DESCRIPTION
This changes how FileIO looks for load and save functions in packages that implement support for a given file format. With this PR, it will first look for functions named ``fileio_load``, ``fileio_save`` etc. If it finds these, it will use them, otherwise it will fall back to the old way of looking for a ``load`` and ``save`` function in the package. So this PR should be completely backwards compatible.

The main benefit of this PR is that it allows a package for a file format to re-export the ``load`` and ``save`` function from FileIO. For example, [CSVFiles.jl](https://github.com/davidanthoff/CSVFiles.jl) will be able to export the function ``FileIO.load`` and ``FileIO.save`` with this patch. Right now it cannot do that: it needs to define a ``CSVFiles.load`` and ``CSVFiles.save`` function, and once those are defined, ``CSVFiles`` can no longer export the ``FileIO`` version of these functions. With this patch, I can change the implementation in CSVFiles.jl to implement ``fileio_load`` and ``fileio_save`` functions, and that opens up the possibility to reexport the functions from FileIO from CSVFiles.

Why is this useful? Right now it is really annoying that one can't just do ``using CSVFiles`` and then start to work, one always has to do a ``using FileIO`` as well. That is just weird and not a good user experience.

I'll add some tests and README stuff if @timholy and @SimonDanisch sign off on the general approach here.