### PR TITLE
`info` should not extend `Base.info`

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -159,7 +159,7 @@ end
 `info(fmt)` returns the magic bytes/extension information for
 `DataFormat` `fmt`.
 """
-Base.info(::Type{DataFormat{sym}}) where {sym} = sym2info[sym]
+info(::Type{DataFormat{sym}}) where {sym} = sym2info[sym]
 
 
 canonicalize_magic(m::NTuple{N,UInt8}) where {N} = m


### PR DESCRIPTION
This was always rather different functionality, and Base.info has been removed. Fixes tests on 1.0.