### PR TITLE
Adding .las format to registry

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -27,7 +27,6 @@ function detect_rdata_single(io)
 end
 
 add_format(format"RDataSingle", detect_rdata_single, [".rds"], [:RData, LOAD])
-
 add_format(format"CSV", (), [".csv"], [:CSVFiles])
 add_format(format"TSV", (), [".tsv"], [:CSVFiles])
 add_format(format"Feather", "FEA1", [".feather"], [:FeatherFiles])
@@ -284,3 +283,5 @@ add_format(format"MetaImage", "ObjectType", ".mhd", [:MetaImageFormat])
 add_format(format"vegalite", (), [".vegalite"], [:VegaLite])
 
 add_format(format"FCS", "FCS", [".fcs"], [:FCSFiles])
+
+add_format(format"LAS", (), [".las",".LAS"],[:LASFiles])


### PR DESCRIPTION
Hi, I am proposing an addition to the registry. This addition is for the LAS file format which is a text based format without magic bytes.

The Log ASCII Standard (LAS) files are used for borehole data such as geophysical, geological, or petrophysical logs in oil and gas wells.
The LAS file specification has been published by [the Canadian Well Logging Society] (http://www.cwls.org/las/)

Note this is not for LiDAR data (also called "LAS files").