### PR TITLE
add BSON data format

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -5,6 +5,7 @@ add_format(format"JLD", (unsafe_wrap(Vector{UInt8}, "Julia data file (HDF5), ver
                          unsafe_wrap(Vector{UInt8}, "Julia data file (HDF5), version 0.1")), ".jld", [:JLD])
 add_format(format"JLD2", "Julia data file (HDF5), version 0.2", ".jld2", [:JLD2])
 add_format(format"GZIP", [0x1f, 0x8b], ".gz", [:Libz])
+add_format(format"BSON",(),".bson", [:BSON])
 
 # test for RD?n magic sequence at the beginning of R data input stream
 function detect_rdata(io)


### PR DESCRIPTION
Hi,
I would like to register the `BSON` data format for usage with `FileIO`.
The PR adding the interface to `BSON` can be found here: https://github.com/MikeInnes/BSON.jl/pull/31