### PR TITLE
WIP: handle NotInstalledError

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -31,7 +31,7 @@ struct NotInstalledError <: Exception
     library::Symbol
     message::String
 end
-function NotInstalledError(e::ArgumentError)
+function NotInstalledError(e::Exception)
     if match(r"Package (.)* not found", e.msg) |> isnothing
         return e
     else


### PR DESCRIPTION
From previous PR https://github.com/JuliaIO/FileIO.jl/pull/76 this feature looks like supported, but I can't find the commit that deprecates this. And looks like `NotInstalledError` isn't used anymore.

I'll work on test cases if this feature is needed, otherwise, I'll close this PR and clean `error_handling.jl` in next PR.

before:
```julia
julia> using TestImages
[ Info: Recompiling stale cache file /home/math/jc/.julia/compiled/v1.1/TestImages/cMlD2.ji for TestImages [5e47fb64-e119-507b-a336-dd2b206d9990]

julia> testimage("ca")
Error encountered while loading "/home/math/jc/.julia/packages/TestImages/6bT9D/images/cameraman.tif".
Fatal error:
ERROR: ArgumentError: Package ImageMagick not found in current path:
- Run `import Pkg; Pkg.add("ImageMagick")` to install the ImageMagick package.

Stacktrace:
 [1] handle_error(::ArgumentError, ::FileIO.File{FileIO.DataFormat{:TIFF}}) at /home/math/jc/.julia/packages/FileIO/e8FNK/src/error_handling.jl:80
 [2] handle_exceptions(::Array{Any,1}, ::String) at /home/math/jc/.julia/packages/FileIO/e8FNK/src/error_handling.jl:75
 [3] #load#27(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::FileIO.File{FileIO.DataFormat{:TIFF}}) at /home/math/jc/.julia/packages/FileIO/e8FNK/src/loadsave.jl:193
 [4] load(::FileIO.File{FileIO.DataFormat{:TIFF}}) at /home/math/jc/.julia/packages/FileIO/e8FNK/src/loadsave.jl:172
 [5] #load#13(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::String) at /home/math/jc/.julia/packages/FileIO/e8FNK/src/loadsave.jl:118
 [6] load at /home/math/jc/.julia/packages/FileIO/e8FNK/src/loadsave.jl:118 [inlined]
 [7] testimage(::String) at /home/math/jc/.julia/packages/TestImages/6bT9D/src/TestImages.jl:88
 [8] top-level scope at none:0
```

after:

```julia
julia> using TestImages
[ Info: Recompiling stale cache file /home/math/jc/.julia/compiled/v1.1/TestImages/cMlD2.ji for TestImages [5e47fb64-e119-507b-a336-dd2b206d9990]

julia> testimage("ca")
Error encountered while loading "/home/math/jc/.julia/packages/TestImages/6bT9D/images/cameraman.tif".
Fatal error:
Library "ImageMagick" is not installed but is recommended as a library to load format: ".tif"
Should we install "ImageMagick" for you? (y/n):
```