### PR TITLE
use `showerror` instead of `println` to display errors

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -72,7 +72,7 @@ function handle_exceptions(exceptions::Vector, action)
     # then handle all errors.
     # this way first fatal exception throws and user can still see all errors
     # TODO, don't throw, if it contains a NotInstalledError?!
-    println(stderr, "Fatal error:")
+    println(stderr, "\nFatal error:")
     for exception in exceptions
         continue_ = handle_error(exception...)
         continue_ || break

--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -63,8 +63,10 @@ function handle_exceptions(exceptions::Vector, action)
     println(stderr, "Error$(multiple ? "s" : "") encountered while $action.")
     if multiple
         println("All errors:")
+        println("===========================================")
         for (err, file) in exceptions
-            println("   ", err)
+            showerror(stdout, err)
+            println("\n===========================================")
         end
     end
     # then handle all errors.


### PR DESCRIPTION
Currently when there are multiple errors they are displayed using `println(err)`. This has caused issues for me because a `MethodError` prints out the argument values in full, which is pretty bad if it's a multi-megabyte array.

This PR updates it to use `showerror(err)` instead, which IMO is also more readable for the user.

Here's some code to generate errors:

```julia
using FileIO, LibSndFile
save("/tmp/test.wav", randn(100), 48000)
```
On `master` the output is:

```
Errors encountered while saving "/tmp/test.wav".
All errors:
   ArgumentError("Package WAV not found in current path:\n- Run `import Pkg; Pkg.add(\"WAV\")` to install the WAV package.\n")
   MethodError(LibSndFile.save_helper, (File{DataFormat{:WAV}}("/tmp/test.wav"), [-0.48550129584070445, 0.44586365763649427, 0.6812538532821187, -0.2878427315129052, -2.5003668460678985, 0.7848597119870627, -1.7911809244022463, -1.1851941801772927, -1.0321010515348137, -0.4166945868822584, -0.6467568456686509, -0.12538059587910472, -0.44650071814287823, 0.9376861568157349, -0.11464289018135622, -0.9504082544467926, -0.03176010791861233, 0.4788961913637828, -0.6321510424152055, -0.09617168721154755, 0.4208089905570868, -1.682601941216775, 0.6075256523587979, -1.655908864537265, -0.29573828809755154, 2.2724276935434884, -0.16748678028604974, -2.8738363242887504, 0.9106185818937815, -0.022907087610996784, -0.8525446888015995, -0.7434424162785848, 1.0657503504682602, 1.1845498057406054, -0.46309372767659934, 1.9252895976805866, 0.6043290282570721, 1.5595050569293378, 0.5365339744666131, 0.5908703885134047, -0.07734402734442507, 0.4179049470513218, 2.2000641877559945, -0.9606956172475938, -1.1828593161489942, -0.9902625037773107, -0.12505715724310462, -2.018792659180565, -0.12364879063074716, -0.7214350940095, 1.2484248023183455, 0.10353958484092911, 0.9872686136690049, -0.1266943243589206, 0.8807294676288167, 0.814316713350304, -0.5821897224877659, -2.365675717584136, 1.0746992783269778, -0.7905210768190687, -1.061726303983368, -0.6272744899412295, 0.19781001347868538, 0.1312608539650471, -1.4728259281383453, 0.6191358323302886, -1.7648099691249017, 0.24814742076278198, 0.14227706518238004, 0.40326298522599197, -0.8543319005103385, 0.8259732750899996, 0.20748496637456362, 0.19585170054401832, 1.0938259796251502, -0.6192427970146687, -0.15503709372760416, 0.5742432286917487, 0.845692814640136, 0.41417914765338537, 1.7120778213654892, -1.3680942665454865, 0.8466464371330314, -0.41000284754579325, -1.8405875577982898, -0.18765626599085244, -0.4948459911164396, 0.7827197044746339, -1.6770106599709567, -0.21752093659826832, 0.3490937439315073, 0.9927591521957994, 1.3583017840912823, -1.1054685969937914, -0.1370674088034042, 1.1910492867508187, 0.6152468299238973, 0.267228065319658, -0.12866387278484442, 1.3938102349830295], 48000), 0x00000000000065fb)
Fatal error:
ERROR: ArgumentError: Package WAV not found in current path:
- Run `import Pkg; Pkg.add("WAV")` to install the WAV package.
```

With this PR the output is:

```
Errors encountered while saving "/tmp/test.wav".
All errors:
===========================================
ArgumentError: Package WAV not found in current path:
- Run `import Pkg; Pkg.add("WAV")` to install the WAV package.

===========================================
MethodError: no method matching save_helper(::File{DataFormat{:WAV}}, ::Array{Float64,1}, ::Int64)
Closest candidates are:
  save_helper(::Any, ::AbstractArray; samplerate) at /home/sfr/.julia/packages/LibSndFile/7s14i/src/loadsave.jl:87
  save_helper(::Any, ::SampledSignals.SampleBuf) at /home/sfr/.julia/packages/LibSndFile/7s14i/src/loadsave.jl:70
===========================================

Fatal error:
ERROR: ArgumentError: Package WAV not found in current path:
- Run `import Pkg; Pkg.add("WAV")` to install the WAV package.
```