### PR TITLE
hotfix/bedgraph

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -160,7 +160,11 @@ add_format(format"FLAC","fLaC",".flac",[:FLAC])
 
 ### Complex cases
 
-# bedGraph: the complication is that the magic bytes may start at any location within an indeterminate header.
+#=
+The bedGraph file format is line-based, and its magic bytes may occur at an indeterminate location within its header.
+Certain conditions must be imposed to constrain the scan for its magic bytes and prevent unnecessary scanning of whole files.
+Lines must start with particular byte strings that are recognisable to the bedGraph format to allow the scan for its magic bytes to continue.
+=#
 function detect_bedgraph(io)
 
     bedgraph_magic = b"type=bedGraph"

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -225,6 +225,11 @@ function detect_bedgraph(io)
 
         pos = 1
 
+        # Allow whitespace.
+        if UInt8('\t') == r || UInt8(' ') == r
+            continue
+        end
+
         # Check whether on "track" and allowed to continue scanning.
         if !keep_scanning && !ontrack
             break # Ending scan for bedGraph magic.

--- a/test/files/file.bedgraph
+++ b/test/files/file.bedgraph
@@ -1,12 +1,14 @@
 browser position chr19:49302001-49304701
-browser hide all
+ browser hide all
 browser pack refGene encodeRegions
-browser full altGraph
+	browser full altGraph
+
+
 #	300 base wide bar graph, autoScale is on by default == graphing
-#	limits will dynamically change to always show full range of data
+  #	limits will dynamically change to always show full range of data
 #	in viewing window, priority = 20 positions this as the second graph
 #	Note, zero-relative, half-open coordinate system in use for bedGraph format
-track type=bedGraph name="BedGraph Format" description="BedGraph format" visibility=full color=200,100,0 altColor=0,100,200 priority=20
+	track type=bedGraph name="BedGraph Format" description="BedGraph format" visibility=full color=200,100,0 altColor=0,100,200 priority=20
 chr19 49302000 49302300 -1.0
 chr19 49302300 49302600 -0.75
 chr19 49302600 49302900 -0.50


### PR DESCRIPTION
This PR prevents `detect_bedgraph` from unnecessarily parsing whole files by adding constraints that need to be overcome to allow the scan for bedGraph magic bytes to continue.

My apologies for the speed issues that `detect_bedgraph` has caused.

Fixes #241.