### PR TITLE
Add new magic bytes for JLD2

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -3,7 +3,8 @@
 # data formats
 add_format(format"JLD", (unsafe_wrap(Vector{UInt8}, "Julia data file (HDF5), version 0.0"),
                          unsafe_wrap(Vector{UInt8}, "Julia data file (HDF5), version 0.1")), ".jld", [:JLD])
-add_format(format"JLD2", "Julia data file (HDF5), version 0.2", ".jld2", [:JLD2])
+add_format(format"JLD2", (unsafe_wrap(Vector{UInt8},"Julia data file (HDF5), version 0.2"),
+                          unsafe_wrap(Vector{UInt8}, "HDF5-based Julia Data Format, version ")), ".jld2", [:JLD2])
 add_format(format"GZIP", [0x1f, 0x8b], ".gz", [:Libz])
 add_format(format"BSON",(),".bson", [:BSON])
 add_format(format"JLSO", (), ".jlso", [:JLSO])


### PR DESCRIPTION
In my opinion it is unlikely for JLD2 to ever become a drop-in replacement for JLD.
Definitely not with full backwards compatibility - so it makes sense for the magic bytes to differ by more than just a version number.
The changes over at JLD2 are here https://github.com/JuliaIO/JLD2.jl/pull/213