### PR TITLE
Don't check magic bytes on save (fixes #267)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,4 +14,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["FilePathsBase", "Test", "Random"]
+test = ["FilePathsBase", "Random", "Test"]

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -114,8 +114,11 @@ savestreaming
 
 # if a bare filename or IO stream are given, query for the format and dispatch
 # to the formatted handlers below
-for fn in (:load, :loadstreaming, :save, :savestreaming, :metadata)
+for fn in (:load, :loadstreaming, :metadata)
     @eval $fn(file, args...; options...) = $fn(query(file), args...; options...)
+end
+for fn in (:save, :savestreaming)
+    @eval $fn(file, args...; options...) = $fn(query(file; checkfile=false), args...; options...)
 end
 
 # return a save function, so you can do `thing_to_save |> save("filename.ext")`

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -292,6 +292,19 @@ end # module Dummy
     @test_throws Exception save("missing.fmt",5)
 end
 
+@testset "Overwrite file with bad magic bytes" begin
+    # issue #267
+    a = [0x01,0x02,0x03]
+    fn = tempname()*".dmy"
+    open(fn, "w") do io
+        write(io, "Ceci n'est pas un DUMMY")
+    end
+    save(fn, a)
+    @test isa(query(fn), File{format"DUMMY"})
+    @test load(fn) == a
+    rm(fn)
+end
+
 del_format(format"DUMMY")
 
 # PPM/PBM can be either binary or text. Test that the defaults work,


### PR DESCRIPTION
This allows `query` to return a format based only on the extension, even if the file already exists. The use-case is for `save` which just overwrites the file; in such cases, it doesn't really make sense to use any pre-existing magic bytes.

CC @dbohdan