### PR TITLE
Restrict precompilation to Julia 1.4.2 and higher

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -62,7 +62,7 @@ include("registry.jl")
 """
 FileIO
 
-if VERSION >= v"1.1.0"
+if VERSION >= v"1.4.2" # https://github.com/JuliaLang/julia/pull/35378
     include("precompile.jl")
     _precompile_()
 end


### PR DESCRIPTION
I've seen one test failure on Julia 1.1, and it's better to be safe than sorry and not take the risk.

CC @kdw503