### PR TITLE
Do checked_import sequentially

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+  JULIA_NUM_THREADS: 2
   matrix:
   - julia_version: 0.7
   - julia_version: 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ julia:
   - 1.0
   - 1
   - nightly
+env:
+  - JULIA_NUM_THREADS=2
 matrix:
   allow_failures:
     - julia: nightly

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -30,8 +30,8 @@ function checked_import(pkg::Symbol)
         m = _findmod(pkg)
         m == nothing || return Base.loaded_modules[m]
         topimport(pkg)
+        return Base.loaded_modules[_findmod(pkg)]
     end
-    return Base.loaded_modules[_findmod(pkg)]
 end
 
 

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -255,6 +255,13 @@ end # module Dummy
     @test load(fn) == a
     rm(fn)
 
+    if Threads.nthreads() > 1
+        Threads.@threads for i in 1:(Threads.nthreads() * 5)
+            fn = string(tempname(), ".dmy")
+            save(fn, a)
+        end
+    end
+
     # force format
     fn = string(tempname(), ".dmy")
     savestreaming(format"DUMMY", fn) do writer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using FileIO
 using FilePathsBase
 using Test
 
+Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), multithread tests will be disabled"
+
 # Both FileIO and FilePathsBase export filename, but we only want the FileIO definition.
 using FileIO: filename
 


### PR DESCRIPTION
The issue at the bottom was submitted to the julia discourse https://discourse.julialang.org/t/segfault-while-loading-images-in-multiple-threads/48878

This PR locks `checked_import` to ensure that loading is sequential in threaded use cases. The cost of the lock when the module is already loaded is negligible. 

`checked_import` execution times in a png-loading loop:
```
[ Info: Precompiling ImageIO [82e4d734-157c-48bb-816b-45c225c6df19]
  0.459511 seconds (7.11 k allocations: 546.457 KiB, 4.52% compilation time)
  0.000005 seconds (1 allocation: 16 bytes)
  0.000004 seconds (1 allocation: 16 bytes)
  0.000003 seconds (1 allocation: 16 bytes)
```

This may slow down parallel loops with heterogenous file types, but even in that case we can't be sure that the IO packages they're loading are themselves using independent deps, so perhaps better to be safe.
_____

Issue from Discourse:
```julia
using Images, FileIO
Threads.@threads for path in readdir("img"; join=true)
  load(path)
end
```
```
signal (11): Segmentation fault
in expression starting at none:1
in expression starting at none:1
unknown function (ip: 0x7fbd79b0d298)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0e80a)
unknown function (ip: 0x7fbd79b0d294)
unknown function (ip: 0x7fbd79b0d725)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0c8b7)
unknown function (ip: 0x7fbd79b0e80a)
unknown function (ip: 0x7fbd79b0d766)
unknown function (ip: 0x7fbd79b0d725)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0c8b7)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0d766)
unknown function (ip: 0x7fbd79b0e80a)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0d725)
unknown function (ip: 0x7fbd79b0d32d)
unknown function (ip: 0x7fbd79b0d9ec)
unknown function (ip: 0x7fbd79b0e80a)
unknown function (ip: 0x7fbd79b0dafc)
unknown function (ip: 0x7fbd79b0d725)
unknown function (ip: 0x7fbd79b0ea0a)
unknown function (ip: 0x7fbd79b0d9ec)
unknown function (ip: 0x7fbd79b12347)
unknown function (ip: 0x7fbd79b0dafc)
jl_restore_incremental at /usr/bin/../lib/libjulia.so.1 (unknown line)
unknown function (ip: 0x7fbd79b0ea0a)
unknown function (ip: 0x7fbd79b12347)
jl_restore_incremental at /usr/bin/../lib/libjulia.so.1 (unknown line)
_include_from_serialized at ./loading.jl:681
_require_search_from_serialized at ./loading.jl:782
_require_search_from_serialized at ./loading.jl:782
Errors encountered while loading "/path/img/000811.png".
All errors:Errors encountered while loading "/path/img/000001.png".

===========================================Errors encountered while loading "/path/img/001081.png".

All errors:
===========================================
All errors:
===========================================
_require at ./loading.jl:1007
_require at ./loading.jl:1007
require at ./loading.jl:928
require at ./loading.jl:928
require at ./loading.jl:923
require at ./loading.jl:923
unknown function (ip: 0x7fbd79b1cac0)
unknown function (ip: 0x7fbd79b1cac0)
unknown function (ip: 0x7fbd79b1e16e)
unknown function (ip: 0x7fbd79b1e16e)
jl_toplevel_eval_in at /usr/bin/../lib/libjulia.so.1 (unknown line)
jl_toplevel_eval_in at /usr/bin/../lib/libjulia.so.1 (unknown line)
eval at ./boot.jl:331 [inlined]
topimport at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:13
eval at ./boot.jl:331 [inlined]
topimport at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:13
checked_import at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:30
checked_import at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:30
#load#28 at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:195
#load#28 at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:195
load at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:184 [inlined]
#load#14 at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:133 [inlined]
load at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:133 [inlined]
macro expansion at /path/open_images.jl:4 [inlined]
#3#threadsfor_fun at ./threadingconstructs.jl:81
load at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:184 [inlined]
#load#14 at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:133 [inlined]
load at /home/someuser/.julia/packages/FileIO/wN5rD/src/loadsave.jl:133 [inlined]
macro expansion at /path/open_images.jl:4 [inlined]
#3#threadsfor_fun at ./threadingconstructs.jl:81
#3#threadsfor_fun at ./threadingconstructs.jl:48
#3#threadsfor_fun at ./threadingconstructs.jl:48
unknown function (ip: 0x7fbd49e314ac)
unknown function (ip: 0x7fbd49e314ac)
unknown function (ip: 0x7fbd79b053b9)
unknown function (ip: 0x7fbd79b053b9)
unknown function (ip: (nil))
nknown function (ip: (nil))
Allocations: 11229080 (Pool: 11225888; Big: 3192); GC: 8
Allocations: 11229080 (Pool: 11225888; Big: 3192); GC: 8
Segmentation fault (core dumped)
```