### PR TITLE
add `.flo` optical flow format

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -55,6 +55,7 @@ add_format(format"NRRD", "NRRD", [".nrrd", ".nhdr"], [:NRRD])
 
 add_format(format"AndorSIF", "Andor Technology Multi-Channel File", ".sif", [:AndorSIF, LOAD])
 
+add_format(format"FLO", b"PIEH", ".flo", [:OpticalFlowUtils])
 
 add_format(format"CRW", UInt8[0x49,0x49,0x1a,0x00,0x00,0x00,0x48,0x45], ".crw", [:ImageMagick])
 add_format(format"CUR", UInt8[0x00,0x00,0x02,0x00],                     ".cur", [:ImageMagick])


### PR DESCRIPTION
This fileformat is somewhat standardized¹ and used in various optical
flow benchmarks²³.
The package is [currently being registered](https://github.com/JuliaRegistries/General/pull/25608).

[1] https://vision.middlebury.edu/flow/code/flow-code/README.txt
[2] https://vision.middlebury.edu/flow/
[3] http://sintel.is.tue.mpg.de/