### PR TITLE
Add Bundle format with BundlerIO.jl

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -146,6 +146,9 @@ add_format(format"2DM", "MESH2D", ".2dm", [:MeshIO])
 add_format(format"OFF", "OFF", ".off", [:MeshIO])
 add_format(format"MSH", (), ".msh", [:MeshIO])
 
+# Bundler SfM format
+add_format(format"OUT", "# Bundle file v0.3\n", ".out", [:BundlerIO])
+
 # GSLIB/SGeMS format (http://gslib.com)
 add_format(format"GSLIB", (), [".gslib",".sgems"], [:GslibIO])
 


### PR DESCRIPTION
Add support for reading and writing files of the [Bundler format](https://www.cs.cornell.edu/~snavely/bundler/bundler-v0.4-manual.html) used for the results of the structure from motion pipeline