### PR TITLE
Try magic bytes func first, if available

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -80,12 +80,18 @@ function query(filename; checkfile::Bool=true)
         elseif !checkfile && lensym(sym) > 1
             return File{DataFormat{sym[1]}}(filename)
         end
-        if no_magic && !hasfunction(sym)
+        no_function = !hasfunction(sym)
+        if no_magic && no_function
             error("Some formats with extension ", ext, " have no magic bytes; use `File{format\"FMT\"}(filename)` to resolve the ambiguity.")
         end
+        if no_magic && !no_function
+            # try specific function first, if available
+            ret = query(open(filename), abspath(filename), sym)
+            !isnothing(ret) && return file!(ret)
+        end
     end
-    !checkfile && return File{unknown_df}(filename) # (no extension || no magic byte) && no file
-    # Otherwise, check the magic bytes
+    !checkfile && return File{unknown_df}(filename) # (no extension || no magic byte || no function) && no file
+    # Otherwise, check against all magic bytes, then functions
     file!(query(open(filename), abspath(filename)))
 end
 
@@ -142,6 +148,28 @@ function query(io::IO, filename = nothing)
         seek(io, pos)
     end
     Stream{unknown_df,typeof(io)}(io, filename)
+end
+function query(io::IO, filename::String, sym::Vector{Symbol})
+    magic = Vector{UInt8}()
+    pos = position(io)
+    if seekable(io)
+        for p in filter(x->last(x) in sym, magic_func)
+            seek(io, pos)
+            f = first(p)
+            try
+                if f(io)
+                    return Stream{DataFormat{last(p)},typeof(io)}(seek(io, pos), filename)
+                end
+            catch e
+                println("There was an error in magick function $f")
+                println("Please open an issue at FileIO.jl. Error:")
+                println(e)
+            end
+        end
+        seek(io, pos)
+    end
+    close(io)
+    nothing
 end
 
 seekable(io::IOBuffer) = io.seekable

--- a/src/query.jl
+++ b/src/query.jl
@@ -156,10 +156,9 @@ function query(io::IO, filename::String, sym::Vector{Symbol})
         for (f, fmtsym) in magic_func
             fmtsym in sym || continue
             seek(io, pos)
-            f = first(p)
             try
                 if f(io)
-                    return Stream{DataFormat{last(p)},typeof(io)}(seek(io, pos), filename)
+                    return Stream{DataFormat{fmtsym},typeof(io)}(seek(io, pos), filename)
                 end
             catch e
                 println("There was an error in magick function $f")

--- a/src/query.jl
+++ b/src/query.jl
@@ -87,7 +87,7 @@ function query(filename; checkfile::Bool=true)
         if no_magic && !no_function
             # try specific function first, if available
             ret = query(open(filename), abspath(filename), sym)
-            ret != nothing && return file!(ret)
+            ret !== nothing && return file!(ret)
         end
     end
     !checkfile && return File{unknown_df}(filename) # (no extension || no magic byte || no function) && no file
@@ -153,7 +153,8 @@ function query(io::IO, filename::String, sym::Vector{Symbol})
     magic = Vector{UInt8}()
     pos = position(io)
     if seekable(io)
-        for p in filter(x->last(x) in sym, magic_func)
+        for (f, fmtsym) in magic_func
+            fmtsym in sym || continue
             seek(io, pos)
             f = first(p)
             try

--- a/src/query.jl
+++ b/src/query.jl
@@ -87,7 +87,7 @@ function query(filename; checkfile::Bool=true)
         if no_magic && !no_function
             # try specific function first, if available
             ret = query(open(filename), abspath(filename), sym)
-            !isnothing(ret) && return file!(ret)
+            ret != nothing && return file!(ret)
         end
     end
     !checkfile && return File{unknown_df}(filename) # (no extension || no magic byte || no function) && no file

--- a/src/registry_setup.jl
+++ b/src/registry_setup.jl
@@ -3,7 +3,7 @@
 const ext2sym    = Dict{String, Union{Symbol,Vector{Symbol}}}()
 const magic_list = Vector{Pair}()     # sorted, see magic_cmp below
 const sym2info   = Dict{Symbol,Any}() # Symbol=>(magic, extension)
-const magic_func = Vector{Pair}()     # for formats with complex magic #s
+const magic_func = Vector{Pair{Function,Symbol}}() # for formats with complex magic #s
 
 ## OS:
 abstract type OS end


### PR DESCRIPTION
In https://github.com/JuliaIO/FileIO.jl/pull/290 I noticed that during `load` all magic byte arrays were being tested for, before the magic bytes function.

Given we can identify if there's a magic bytes function earlier, it might make sense to test that before the exhaustive test?

I've only tested this with that ImageIO PR, where load of a small file went from `192.159 μs (414 allocations: 19.67 KiB)` to `125.654 μs (325 allocations: 16.22 KiB)`