### PR TITLE
Identify TIFF format in IOBuffer

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -257,10 +257,10 @@ function detecttiff(io)
     return any(map(x->all(magic .== x), tiff_magic))
 end
 # normal TIFF
-detect_noometiff(io) = detecttiff(io) && !(endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
+detect_noometiff(io) = detecttiff(io) && (!hasproperty(io, :name) || !(endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>")))
 add_format(format"TIFF", detect_noometiff, [".tiff", ".tif"], [:QuartzImageIO, OSX], [:ImageMagick])
 # OME-TIFF
-detect_ometiff(io) = detecttiff(io) && (endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
+detect_ometiff(io) = detecttiff(io) && hasproperty(io, :name) && (endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
 add_format(format"OMETIFF", detect_ometiff, [".tif", ".tiff"], [:OMETIFF])
 
 # custom skipmagic functions for function-based tiff magic detection

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -257,10 +257,10 @@ function detecttiff(io)
     return any(map(x->all(magic .== x), tiff_magic))
 end
 # normal TIFF
-detect_noometiff(io) = detecttiff(io) && (!hasproperty(io, :name) || !(endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>")))
+detect_noometiff(io) = detecttiff(io) && ((:name ∉ propertynames(io)) || !(endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>")))
 add_format(format"TIFF", detect_noometiff, [".tiff", ".tif"], [:QuartzImageIO, OSX], [:ImageMagick])
 # OME-TIFF
-detect_ometiff(io) = detecttiff(io) && hasproperty(io, :name) && (endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
+detect_ometiff(io) = detecttiff(io) && (:name ∈ propertynames(io)) && (endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
 add_format(format"OMETIFF", detect_ometiff, [".tif", ".tiff"], [:OMETIFF])
 
 # custom skipmagic functions for function-based tiff magic detection

--- a/test/query.jl
+++ b/test/query.jl
@@ -347,6 +347,17 @@ file_path = Path(file_dir)
     end
 end
 
+@testset "Query from IOBuffer" begin
+    streamformat(::Stream{T, U}) where {T, U} = T
+    for name ∈ ["magic1.tiff", "magic2.tiff"]
+        pth = joinpath(file_dir, "magic2.tiff")
+        open(pth) do io
+            buf=IOBuffer(read(io))
+            @test streamformat(query(buf)) == DataFormat{:TIFF}
+        end
+    end
+end
+
 @testset "Format with function for magic bytes" begin
     add_format(format"FUNCTION_FOR_MAGIC_BYTES", x -> 0x00, ".wav", [:WAV])
     del_format(format"FUNCTION_FOR_MAGIC_BYTES")


### PR DESCRIPTION
IOBuffer does not necessarily have a `:name` property, if it is not present fall back to using only magic bytes.