### PR TITLE
Fix typo in save method

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -145,7 +145,7 @@ end
 # return a save function, so you can do `thing_to_save |> save("filename.ext")`
 function save(file; options...)
     sym = querysym(file; checkfile=false)
-    libraries = applicable_loaders(sym)
+    libraries = applicable_savers(sym)
     return data -> action(:save, libraries, sym, file, data; options...)
 end
 


### PR DESCRIPTION
Edit: It's just a typo

___

I think exposure of the MimeWriter save functions may have inadvertently dropped off in the refactor, with the change from

https://github.com/JuliaIO/FileIO.jl/blob/71bdffe1f3933aa51e7d7c42f50b90589e52d7f4/src/loadsave.jl#L143-L144

to 

https://github.com/JuliaIO/FileIO.jl/blob/b779539b505ba5aea6634c5cb78b2d2cc6e49ac8/src/loadsave.jl#L145-L150

At least, seems to fix https://github.com/JuliaIO/FileIO.jl/issues/310 for me.

I very much defer to @timholy's judgement here though about whether this is the right way to fix it

cc. @davidanthoff 