### PR TITLE
add AVI MP4 OGG and Matroska video container support via VideoIO

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     for f in (detect_rdata, detect_rdata_single, detectwav, detect_bedgraph,
-              detecttiff, detect_noometiff, detect_ometiff, detect_avi,
+              detecttiff, detect_noometiff, detect_ometiff, detectavi,
               detecthdf5, detect_stlascii, detect_stlbinary, detect_gadget2)
         @assert precompile(f, (IOStream,))
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     for f in (detect_rdata, detect_rdata_single, detectwav, detect_bedgraph,
-              detecttiff, detect_noometiff, detect_ometiff, detectavi,
+              detecttiff, detect_noometiff, detect_ometiff, detect_avi,
               detecthdf5, detect_stlascii, detect_stlbinary, detect_gadget2)
         @assert precompile(f, (IOStream,))
     end

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -178,7 +178,7 @@ add_format(
 # Video formats
 
 # AVI is a subtype of RIFF, as is WAV
-function detect_avi(io)
+function detectavi(io)
     getlength(io) >= 12 || return false
     magic = read!(io, Vector{UInt8}(undef, 4))
     magic == b"RIFF" || return false
@@ -187,7 +187,7 @@ function detect_avi(io)
 
     submagic == b"AVI "
 end
-add_format(format"AVI", detect_avi, ".avi", [idImageMagick], [idVideoIO])
+add_format(format"AVI", detectavi, ".avi", [idImageMagick], [idVideoIO])
 add_format(format"MP4", UInt8[0x00,0x00,0x00,0x18,0x66,0x74,0x79,0x70], ".mp4", [idVideoIO])
 add_format(format"OGG", UInt8[0x4F,0x67,0x67,0x53], [".ogg",".ogv"], [idVideoIO])
 add_format(format"MATROSKA", UInt8[0x1A,0x45,0xDF,0xA3], [".mkv",".mks",".webm"], [idVideoIO])

--- a/test/query.jl
+++ b/test/query.jl
@@ -384,16 +384,31 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
         end
         @testset "AVI Detection" begin
             open(joinpath(file_dir, "bees.avi")) do s
-                @test FileIO.detectavi(s)
+                @test FileIO.detect_avi(s)
             end
             open(joinpath(file_dir, "sin.wav")) do s
-                @test !(FileIO.detectavi(s))
+                @test !(FileIO.detect_avi(s))
             end
             open(joinpath(file_dir, "magic1.tiff")) do s
-                @test !(FileIO.detectavi(s))
+                @test !(FileIO.detect_avi(s))
             end
             q = query(joinpath(file_dir, "bees.avi"))
             @test typeof(q) <: File{format"AVI"}
+        end
+        @testset "MP4 detection" begin
+            f = download("https://archive.org/download/LadybirdOpeningWingsCCBYNatureClip/Ladybird%20opening%20wings%20CC-BY%20NatureClip.mp4")
+            q = query(f)
+            @test typeof(q) <: File{format"MP4"}
+        end
+        @testset "OGG detection" begin
+            f = download("https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv")
+            q = query(f)
+            @test typeof(q) <: File{format"OGG"}
+        end
+        @testset "MATROSKA detection" begin
+            f = download("https://upload.wikimedia.org/wikipedia/commons/1/13/Artist%E2%80%99s_impression_of_the_black_hole_inside_NGC_300_X-1_%28ESO_1004c%29.webm")
+            q = query(f)
+            @test typeof(q) <: File{format"MATROSKA"}
         end
         @testset "WAV detection" begin
             open(joinpath(file_dir, "sin.wav")) do s

--- a/test/query.jl
+++ b/test/query.jl
@@ -384,13 +384,13 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
         end
         @testset "AVI Detection" begin
             open(joinpath(file_dir, "bees.avi")) do s
-                @test FileIO.detect_avi(s)
+                @test FileIO.detectavi(s)
             end
             open(joinpath(file_dir, "sin.wav")) do s
-                @test !(FileIO.detect_avi(s))
+                @test !(FileIO.detectavi(s))
             end
             open(joinpath(file_dir, "magic1.tiff")) do s
-                @test !(FileIO.detect_avi(s))
+                @test !(FileIO.detectavi(s))
             end
             q = query(joinpath(file_dir, "bees.avi"))
             @test typeof(q) <: File{format"AVI"}


### PR DESCRIPTION
As of `VideoIO` v0.9.1 there are simple `VideoIO.save` and `VideoIO.load` functions, which are extended to the `fileio_save` `fileio_load` names here
https://github.com/JuliaIO/VideoIO.jl/blob/77091893d21aae80cf7bca2c8550f0b55f029b36/src/VideoIO.jl#L111-L113

This adds basic functionality to load the entire video as a framestack, or write an entire framestack to file in one go.

FFMPEG can support a lot of file/container/codec types, but I thought I'd start with the common ones.

I tried to figure out how to add .mov but the magic bytes are a bit confusing. Happy to add them if someone figures out a decent heuristic.

```julia
julia> @time vid = FileIO.load("/Users/ian/Documents/GitHub/VideoIO.jl/videos/ladybird.mp4");
  4.754831 seconds (3.33 k allocations: 2.300 GiB, 6.35% gc time)

julia> typeof(vid)
Vector{PermutedDimsArray{RGB{N0f8}, 2, (2, 1), (2, 1), Matrix{RGB{N0f8}}}} (alias for Array{PermutedDimsArray{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8, 8}}, 2, (2, 1), (2, 1), Array{ColorTypes.RGB{FixedPointNumbers.Normed{UInt8, 8}}, 2}}, 1})

julia> size(vid)
(397,)

julia> size(vid[1])
(1080, 1920)

julia> @time FileIO.save("/Users/ian/Documents/GitHub/VideoIO.jl/videos/ladybird2.mp4", vid);
 10.289047 seconds (1.71 k allocations: 30.203 KiB)

julia> @time FileIO.save("/Users/ian/Documents/GitHub/VideoIO.jl/videos/ladybird2.mp4", vid, encoder_options = (color_range=2, crf=0, preset="ultrafast"));
  3.476963 seconds (1.73 k allocations: 30.797 KiB)
```

Note that this puts VideoIO ~before~ AFTER the existing ImageMagick AVI support. ~We may want to be more conservative and leave ImageMagick in first place?~