### PR TITLE
Do not use isfile for URLs in checkpath_load

### DIFF
--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -164,7 +164,7 @@ end
 function checkpath_load(file)
     file === nothing && return nothing   # likely stream io
     isa(file, IO) && return nothing
-    !isfile(file) && throw(ArgumentError("No file exists at given path: $file"))
+    startswith(file, "http://") || startswith(file, "https://") || !isfile(file) && throw(ArgumentError("No file exists at given path: $file"))
     return nothing
 end
 function checkpath_save(file)


### PR DESCRIPTION
Fixes #320. Not sure this is the best solution, but it would still be great if we could merge this quickly and tag a new release, so that the functionality in CSVFiles.jl is no longer broken.