### PR TITLE
fallback to extension-based guess when querying an empty file

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -93,7 +93,9 @@ function querysym(filename; checkfile::Bool=true)
             return open(filename) do io
                 match(io, magic) && return sym
                 # if it doesn't match, we prioritize the magic bytes over the guess based on extension
-                return querysym_all(io)[1]
+                fmt = querysym_all(io)[1]
+                # but if it fails to query the magic bytes, still use the extension-based guess
+                return fmt === :UNKNOWN ? sym : fmt
             end
         end
         # There are multiple formats consistent with this extension
@@ -110,7 +112,8 @@ function querysym(filename; checkfile::Bool=true)
                 match(io, magic) && return sym
             end
             badmagic && error("Some formats with extension ", ext, " have no magic bytes; use `File{format\"FMT\"}(filename)` to resolve the ambiguity.")
-            return querysym_all(io)[1]
+            fmt = querysym_all(io)[1]
+            return fmt === :UNKNOWN ? syms[1] : fmt
         end
     end
     !checkfile && return :UNKNOWN

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -58,6 +58,7 @@ detect_compressed(io, len=getlength(io); kwargs...) = detect_compressor(io, len;
 # test for RD?n magic sequence at the beginning of R data input stream
 function detect_rdata(io)
     seekstart(io)
+    getlength(io) <= 4 && return false
     b = read(io, UInt8)
     if b == UInt8('R')
         return read(io, UInt8) == UInt8('D') &&

--- a/test/query.jl
+++ b/test/query.jl
@@ -484,4 +484,15 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
             end
         end
     end
+
+    @testset "issue #338" begin
+        open("test.png", "w") do io
+            write(io, UInt8('R'))
+        end
+        q = query("test.png")
+        @test FileIO.formatname(q) == :PNG
+        q = query("test.png"; checkfile=false)
+        @test FileIO.formatname(q) == :PNG
+        rm("test.png")
+    end
 end


### PR DESCRIPTION
Also fixes the `detect_rdata` function so that it's happy with an empty file.

fixes #338

This is considered as a bug fix, so I'll tag a new patch version when it's merged.