### PR TITLE
check eof before read bytes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "0.7, 1"
 
 [extras]
 CSVFiles = "5d742f6a-9f54-50ce-8119-2520741973ca"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -20,4 +21,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorTypes", "CSVFiles", "FilePathsBase", "HTTP", "Random", "Test"]
+test = ["ColorTypes", "CodecZlib", "CSVFiles", "FilePathsBase", "HTTP", "Random", "Test"]

--- a/test/query.jl
+++ b/test/query.jl
@@ -518,4 +518,22 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
         @test FileIO.formatname(q) == :PNG
         rm("test.png")
     end
+
+    @testset "issue #345" begin
+        iris = joinpath("files", "iris.rda")
+
+        q = query(iris)
+        @test typeof(q) <: File{format"RData"}
+
+        io = open(iris)
+        q = query(io)
+        @test typeof(q) <: Stream{format"GZIP"} # FIXME: should be RData
+        @test FileIO.detect_rdata(io)
+        
+        # issue #345: it errors here
+        io = CodecZlib.GzipDecompressorStream(open(iris))
+        q = query(io)
+        @test FileIO.unknown(q) # FIXME: should be RData
+        @test FileIO.detect_rdata(io)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using FileIO
 using FilePathsBase
 using Test
 using UUIDs
+using CodecZlib
 
 Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), multithread tests will be disabled"
 


### PR DESCRIPTION
#345 is introduced by #343. It turns out that `seek` is not defined for GZip stream object `GzipDecompressor`, so here it uses a per-byte strategy to check the io length.

This is a bug fix so I'll merge quickly and tag a patch version for it.

fixes #345

cc: @jonasjonker @alyst