### PR TITLE
Limit output when printing errors

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -8,7 +8,7 @@ struct LoaderError <: Exception
     msg::String
     ex
 end
-Base.showerror(io::IO, e::LoaderError) = println(io, e.library, " load error: ",
+Base.showerror(io::IO, e::LoaderError) = println(IOContext(io, :limit=>true), e.library, " load error: ",
                                                  e.msg, "\n  due to ", e.ex, "\n  Will try next loader.")
 
 """
@@ -22,7 +22,7 @@ struct WriterError <: Exception
     ex
 end
 Base.showerror(io::IO, e::WriterError) = println(
-    io, e.library, " writer error: ",
+    IOContext(io, :limit=>true), e.library, " writer error: ",
     e.msg, "\n  due to ", e.ex, "\n  Will try next loader."
 )
 


### PR DESCRIPTION
For some errors, the entire data set being saved can be printed to
the terminal when an error is thrown. This  reduces the output.