### PR TITLE
FileIO v1.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FileIO"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.11.2"
+version = "1.12.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
- [x] [registry] register ImageIO for sixel format (#355)
- [x] [registry] add QOI.jl to read and save the qoi image format  (#354)