### PR TITLE
Add Gziped fits file support and AstroImages.jl library

### DIFF
--- a/test/query.jl
+++ b/test/query.jl
@@ -540,7 +540,7 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
 
         io = open(iris)
         q = query(io)
-        @test typeof(q) <: Stream{format"GZIP"} # FIXME: should be RData
+        @test typeof(q) <: Stream{format"RData"}
         @test FileIO.detect_rdata(io)
 
         # issue #345: it errors here


### PR DESCRIPTION
This PR adds support for loading GZiped FITS files.
Astronomical FITS files are often gziped and given an extension like `.fits.gz`. Compressed fits files can be loaded directly by FITSIO.

I did my best to untangle the file loading between plain GZiped files, GZiped RData files, and GZiped fits files. 
Everything should work exactly as before unless a filename matches the `.fits.gz` pattern.
I believe this also fixes one `#FIXME` comment in `tests/query.jl` for compressed RData.

Finally, I also add support for the AstroImages library as an alternative to FITSIO which was my original purpose 😅.


