### PR TITLE
Add .bib files to FileIO interface

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -527,3 +527,6 @@ add_format(format"HTML", (), [".html", ".htm"], [MimeWriter, SAVE])
 add_format(format"MIDI", "MThd", [".mid", ".midi", ".MID"], [:MIDI => UUID("f57c4921-e30c-5f49-b073-3f2f2ada663e")])
 
 add_format(format"QOI", "qoif", ".qoi", [:QOI => UUID("4b34888f-f399-49d4-9bb3-47ed5cae4e65")], [idImageIO])
+
+# Bibliography files.
+add_format(format"BIB", (), [".bib"], [:Bibliography => UUID("f1be7e48-bf82-45af-a471-ae754a193061")])

--- a/test/files/file.bib
+++ b/test/files/file.bib
@@ -1,0 +1,148 @@
+@misc{CiteEprint,
+ primaryClass  = {cs.AI},
+ author        = {Richoux, Florian and Baffier, Jean-François},
+ eprint        = {2002.09811},
+ year          = {2020},
+ url           = {https://arxiv.org/abs/2002.09811},
+ archivePrefix = {arXiv},
+ title         = {Automatic Cost Function Learning with Interpretable Compositional Networks}
+}
+
+@article{CitekeyArticle,
+ number        = {6},
+ pages         = {1143--1148},
+ author        = {Cohen, P.  J.},
+ year          = {1963},
+ volume        = {50},
+ journal       = {Proceedings of the National Academy of Sciences},
+ title         = {The independence of the continuum hypothesis}
+}
+
+@book{CitekeyBook,
+ publisher     = {Penguin Random House},
+ address       = {New York, NY},
+ author        = {Susskind, Leonard and Hrabovsky, George},
+ year          = {2014},
+ title         = {Classical mechanics: the theoretical minimum}
+}
+
+@booklet{CitekeyBooklet,
+ howpublished  = {Distributed at the Stockholm Tourist Office},
+ publisher     = {Penguin Random House},
+ address       = {New York, NY},
+ author        = {Swetla, Maria},
+ year          = {2015},
+ month         = {{July}},
+ title         = {Canoe tours in {S}weden}
+}
+
+@inbook{CitekeyInbook,
+ howpublished  = {Distributed at the Stockholm Tourist Office},
+ publisher     = {Pearson},
+ pages         = {187--221},
+ address       = {New York, NY},
+ booktitle     = {Campbell Biology},
+ author        = {Urry, Lisa  A. and Cain, Michael  L. and Wasserman, Steven  A. and Minorsky, Peter  V. and Reece, Jane  B.},
+ year          = {2016},
+ month         = {{July}},
+ title         = {Photosynthesis}
+}
+
+@incollection{CitekeyIncollection,
+ publisher     = {Springer},
+ pages         = {1--10},
+ address       = {New York, NY},
+ booktitle     = {Flow Cytometry Protocols},
+ author        = {Shapiro, Howard M.},
+ editor        = {Hawley, Teresa S. and Hawley, Robert G.},
+ year          = {2018},
+ title         = {Flow Cytometry: The Glass Is Half Full}
+}
+
+@inproceedings{CitekeyInproceedings,
+ publisher     = {ACM},
+ pages         = {207--216},
+ address       = {New York, NY},
+ booktitle     = {Proc. of the 6th Nordic Conf. on Human-Computer Interaction},
+ author        = {Holleis, Paul and Wagner, Matthias and Koolwaaij, Johan},
+ series        = {NordiCHI},
+ year          = {2010},
+ title         = {Studying mobile context-aware social services in the wild}
+}
+
+@manual{CitekeyManual,
+ organization  = {R Foundation for Statistical Computing},
+ address       = {Vienna, Austria},
+ author        = {Team, R  Core},
+ year          = {2018},
+ title         = {{R}: A Language and Environment for Statistical Computing}
+}
+
+@mastersthesis{CitekeyMastersthesis,
+ organization  = {R Foundation for Statistical Computing},
+ school        = {Massachusetts Institute of Technology},
+ address       = {Cambridge, MA},
+ author        = {Tang, Jian},
+ year          = {1996},
+ month         = {Septembre},
+ title         = {Spin structure of the nucleon in the asymptotic limit}
+}
+
+@misc{CitekeyMisc,
+ howpublished  = {\url{https://www.nasa.gov/nh/pluto-the-other-red-planet}},
+ author        = {NASA},
+ note          = {Accessed: 2018-12-06},
+ year          = {2015},
+ title         = {Pluto: The 'Other' Red Planet}
+}
+
+@phdthesis{CitekeyPhdthesis,
+ school        = {Stanford University},
+ address       = {Stanford, CA},
+ author        = {Rempel, Robert Charles},
+ year          = {1956},
+ month         = {June},
+ title         = {Relaxation Effects for Coupled Nuclear Spins}
+}
+
+@proceedings{CitekeyProceedings,
+ publisher     = {Springer},
+ address       = {Cham, Switzerland},
+ editor        = {Stepney, Susan and Verlan, Sergey},
+ series        = {Lecture Notes in Computer Science},
+ year          = {2018},
+ volume        = {10867},
+ title         = {Proceedings of the 17th International Conference on Computation and Natural Computation, Fontainebleau, France}
+}
+
+@techreport{CitekeyTechreport,
+ author        = {Bennett, Vicki and Bowman, Kate and Wright, Sarah},
+ editor        = {Stepney, Susan and Verlan, Sergey},
+ month         = {September},
+ title         = {{W}asatch {S}olar {P}roject Final Report},
+ publisher     = {Springer},
+ number        = {DOE-SLC-6903-1},
+ address       = {Salt Lake City, UT},
+ series        = {Lecture Notes in Computer Science},
+ year          = {2018},
+ volume        = {10867},
+ institution   = {Salt Lake City Corporation}
+}
+
+@unpublished{CitekeyUnpublished,
+ author        = {Suresh, Mohinder},
+ note          = {Well, a note},
+ year          = {2006},
+ title         = {Evolution: a revised theory}
+}
+
+@misc{baffier2017experimental,
+ primaryClass  = {cs.DS},
+ author        = {Baffier, Jean-François and Diez, Yago and Korman, Matias},
+ note          = {Well, a note},
+ eprint        = {1706.04708},
+ year          = {2017},
+ url           = {https://arxiv.org/abs/1706.04708},
+ archivePrefix = {arXiv},
+ title         = {Experimental Study of Compressed Stack Algorithms in Limited Memory Environments}
+}

--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -13,6 +13,7 @@ end
 module TestLoadSave2
     import FileIO: File, @format_str
     fileio_load(file::File{format"HDF5"})      = "HDF5"
+    fileio_load(file::File{format"BIB"})       = "BIB"
 end
 
 @testset "FakeIO" begin
@@ -32,6 +33,7 @@ end
             add_loader(format"HDF5", TestLoadSave2)
             add_loader(format"JLD", TestLoadSave)
             add_loader(format"GZIP", TestLoadSave)
+            add_loader(format"BIB", TestLoadSave2)
 
             @test load(joinpath(fp,"file1.pbm")) == "PBMText"
             @test load(joinpath(fp,"file2.pbm")) == "PBMBinary"
@@ -49,6 +51,8 @@ end
             @test load(joinpath(fp,"file.jld")) == "JLD"
             # GZIP file saved with .gz extension
             @test load(joinpath(fp,"file.csv.gz")) == "GZIP"
+            # Bibliography file saved with .bib extension
+            @test load(joinpath(fp,"file.bib")) == "BIB"
             @test_throws Exception load("missing.fmt")
         end
     finally

--- a/test/query.jl
+++ b/test/query.jl
@@ -508,6 +508,11 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
             q = query(joinpath(file_dir, "file2.h5"))
             @test typeof(q) <: File{format"HDF5"}
         end
+
+        @testset "Bibliography detection" begin
+            q = query(joinpath(file_dir, "file.bib"))
+            @test typeof(q) <: File{format"BIB"}
+        end
     end
 
     @testset "Query from IOBuffer" begin


### PR DESCRIPTION
The .bib files store bibliography data which can be used in a LaTeX document. This PR registers ".bib" files with [Bibliography.jl](https://github.com/Humans-of-Julia/Bibliography.jl), which can handle parsing / importing / exporting / processing the Bibliography data.

The FileIO interfaces have been added in https://github.com/Humans-of-Julia/Bibliography.jl/pull/47