### PR TITLE
Add support for ppi argument for PNG files

### DIFF
--- a/src/mimesave.jl
+++ b/src/mimesave.jl
@@ -2,10 +2,14 @@ module MimeWriter
 
 using ..FileIO: File, @format_str
 
-function save(file::File{format"PNG"}, data)
+function save(file::File{format"PNG"}, data; ppi::Union{Nothing,Number}=nothing)
     if showable("image/png", data)
         open(file.filename, "w") do s
-            show(IOContext(s, :full_fidelity=>true), "image/png", data)
+            if isnothing(ppi)
+                show(IOContext(s, :full_fidelity=>true), "image/png", data)
+            else
+                show(IOContext(s, :full_fidelity=>true, :ppi=>ppi), "image/png", data)
+            end
         end
     else
         throw(ArgumentError("Argument does not support conversion to png."))


### PR DESCRIPTION
With this one will be able to set a ppi configuration when saving Vega.jl or VegaLite.jl plots. For example:

```julia
@vlplot(:point, rand(10), rand(10)) |> save("foo.png", ppi=300)
```
will work.