### PR TITLE
Add support for OpenCV.jl

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -150,7 +150,7 @@ add_format(format"EXR", UInt8[0x76,0x2f,0x31,0x01],                     ".exr", 
 add_format(format"HDR", UInt8[0x23,0x3f,0x52,0x41,0x44,0x49,0x41,0x4e], ".hdr", [idImageMagick])
 add_format(format"ICO", UInt8[0x00,0x00,0x01,0x00],                     ".ico", [idImageMagick])
 add_format(format"INFO", UInt8[0x7a,0x62,0x65,0x78],                    ".info",[idImageMagick])
-add_format(format"JP2", UInt8[0x00,0x00,0x00,0x0c,0x6a,0x50,0x20,0x20], ".jp2", [idImageMagick])
+add_format(format"JP2", UInt8[0x00,0x00,0x00,0x0c,0x6a,0x50,0x20,0x20], ".jp2", [idImageMagick], [idOpenCV])
 add_format(format"PDB", UInt8[0x73,0x7a,0x65,0x7a],                     ".pdb", [idImageMagick])
 add_format(format"PDF", UInt8[0x25,0x50,0x44,0x46],                     ".pdf", [idImageMagick], [MimeWriter, SAVE])
 add_format(format"PGM", UInt8[0x50,0x35,0x0a],                          ".pgm", [idImageMagick])
@@ -199,7 +199,8 @@ add_format(
     UInt8[0x42,0x4d],
     ".bmp",
     [idQuartzImageIO, OSX],
-    [idImageMagick]
+    [idImageMagick],
+    [idOpenCV]
 )
 add_format(
     format"PCX",
@@ -388,7 +389,7 @@ function detecttiff(io)
 end
 # normal TIFF
 detect_noometiff(io) = detecttiff(io) && ((:name ∉ propertynames(io)) || !(endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>")))
-add_format(format"TIFF", detect_noometiff, [".tiff", ".tif"], [idImageIO], [idQuartzImageIO, OSX], [idImageMagick])
+add_format(format"TIFF", detect_noometiff, [".tiff", ".tif"], [idImageIO], [idQuartzImageIO, OSX], [idImageMagick], [idOpenCV])
 # OME-TIFF
 detect_ometiff(io) = detecttiff(io) && (:name ∈ propertynames(io)) && (endswith(io.name, ".ome.tif>") || endswith(io.name, ".ome.tiff>"))
 add_format(format"OMETIFF", detect_ometiff, [".tif", ".tiff"], [:OMETIFF => UUID("2d0ec36b-e807-5756-994b-45af29551fcf")])

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -7,6 +7,7 @@ const idImageIO = :ImageIO => UUID("82e4d734-157c-48bb-816b-45c225c6df19")
 const idImageMagick = :ImageMagick => UUID("6218d12a-5da1-5696-b52f-db25d2ecc6d1")
 const idMeshIO = :MeshIO => UUID("7269a6da-0436-5bbc-96c2-40638cbb6118")
 const idNetpbm = :Netpbm => UUID("f09324ee-3d7c-5217-9330-fc30815ba969")
+const idOpenCV = :OpenCV => UUID("f878e3a2-a245-4720-8660-60795d644f2a")
 const idQuartzImageIO = :QuartzImageIO => UUID("dca85d43-d64c-5e67-8c65-017450d5d020")
 const idRData = :RData => UUID("df47a6cb-8c03-5eed-afd8-b6050d6c41da")
 const idStatFiles = :StatFiles => UUID("1463e38c-9381-5320-bcd4-4134955f093a")
@@ -180,6 +181,7 @@ add_format(
     [idImageIO],
     [idQuartzImageIO, OSX],
     [idImageMagick],
+    [idOpenCV],
     [MimeWriter, SAVE]
 )
 add_format(
@@ -189,7 +191,8 @@ add_format(
     [idJpegTurbo],
     [idImageIO],
     [idQuartzImageIO, OSX],
-    [idImageMagick]
+    [idImageMagick],
+    [idOpenCV]
 ) # 0xe1
 add_format(
     format"BMP",


### PR DESCRIPTION
OpenCV.jl read and write several image [formats](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56).

This PR covers major image formats. 