### PR TITLE
Update CI for mac aarch64, codecov 4 token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,25 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1.6', '1', 'nightly']
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        julia-arch: [x64, x86, aarch64]
+        os: [ubuntu-latest, windows-latest, macOS-13, macOS-14]
         exclude:
-          - os: macOS-latest
-            julia-arch: x86
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
+          - os: macOS-13
+            arch: x86
+          - os: macOS-13
+            arch: aarch64
+          - os: macOS-14
+            arch: x86
+          - os: macOS-14
+            arch: x64
+          - os: macOS-14
+            version: '1.6'
+          - os: macOS-14
+            version: '1.0'
 
     steps:
       - name: Set git to use LF (Windows only)
@@ -42,3 +56,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,21 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-13, macOS-14]
         exclude:
           - os: ubuntu-latest
-            arch: aarch64
+            julia-arch: aarch64
           - os: windows-latest
-            arch: aarch64
+            julia-arch: aarch64
           - os: macOS-13
-            arch: x86
+            julia-arch: x86
           - os: macOS-13
-            arch: aarch64
+            julia-arch: aarch64
           - os: macOS-14
-            arch: x86
+            julia-arch: x86
           - os: macOS-14
-            arch: x64
+            julia-arch: x64
           - os: macOS-14
-            version: '1.6'
+            julia-version: '1.6'
           - os: macOS-14
-            version: '1.0'
+            julia-version: '1.0'
 
     steps:
       - name: Set git to use LF (Windows only)


### PR DESCRIPTION
I wonder if we can drop testing for 1.0 and save CI time.