### PR TITLE
Fix syntax in example in documentation

### DIFF
--- a/docs/src/registering.md
+++ b/docs/src/registering.md
@@ -15,7 +15,7 @@ Before going into detail explaining the arguments of `add_format`,
 here is a real example that could be used to register an I/O package for one of the [Netpbm image formats](https://en.wikipedia.org/wiki/Netpbm#File_formats):
 
 ```
-add_format(format"PPMBinary", "P6", ".ppm", [:Netpbm => UUID("f09324ee-3d7c-5217-9330-fc30815ba969")]
+add_format(format"PPMBinary", "P6", ".ppm", [:Netpbm => UUID("f09324ee-3d7c-5217-9330-fc30815ba969")])
 ```
 
 Briefly, this indicates that files in this format typically have extension `.ppm`, the file contents typically start with "P6" (the byte sequence `[0x50, 0x36]`), and these files can be read and written by the [Netpbm package](https://github.com/JuliaIO/Netpbm.jl). (The `UUID` is Julia's unique identifier for this registered package and can be obtained from the `Project.toml` file.)


### PR DESCRIPTION
A parenthesis was missing.