### PR TITLE
Fix Documenter CI

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: nightly               # change this to 1.6 once's that's official
+          version: '1.10'
           show-versioninfo: true         # this causes versioninfo to be printed to the action log
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,4 +1,5 @@
 name: Documenter
+
 on:
   push:
     branches: [master]
@@ -7,6 +8,10 @@ on:
 
 jobs:
   Documenter:
+    permissions:
+      contents: write
+      pull-requests: read
+      statuses: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Switches Documenter CI from Julia nightly to 1.10

This avoids the issue in:
https://github.com/julia-actions/GitHubActions.jl/pull/34