### PR TITLE
Make Formatted <: IO to avoid invalidations

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -21,7 +21,7 @@ end
 formatname(::Type{DataFormat{sym}}) where sym = sym
 
 
-abstract type Formatted{F<:DataFormat} end  # A specific file or stream
+abstract type Formatted{F<:DataFormat} <: IO end  # A specific file or stream
 
 formatname(::Formatted{F}) where F<:DataFormat = formatname(F)
 
@@ -146,15 +146,8 @@ Base.seekend(@nospecialize(s::Stream)) = (seekend(stream(s)); s)
 Base.skip(@nospecialize(s::Stream), offset::Integer) = (skip(stream(s), offset); s)
 Base.eof(s::Stream) = eof(stream(s))
 
-@inline Base.read(s::Stream, args...)  = read(stream(s), args...)
-Base.read!(s::Stream, array::Array) = read!(stream(s), array)
-@inline Base.write(s::Stream, args...) = write(stream(s), args...)
-# Note: we can't sensibly support the all keyword. If you need that,
-# call read(stream(s), ...; all=value) manually
-Base.readbytes!(s::Stream, b) = readbytes!(stream(s), b)
-Base.readbytes!(s::Stream, b, nb) = readbytes!(stream(s), b, nb)
-Base.read(s::Stream) = read(stream(s))
-Base.read(s::Stream, nb) = read(stream(s), nb)
+@inline Base.write(s::Stream, x::UInt8) = write(stream(s), x)
+@inline Base.read(s::Stream, ::Type{UInt8}) = read(stream(s), UInt8)
 Base.flush(s::Stream) = flush(stream(s))
 
 Base.isreadonly(s::Stream) = isreadonly(stream(s))


### PR DESCRIPTION
Addresses #396, and further seems to simplify the implementation a little.

This change is a bit weird, as `Formatted` itself does not semantically represent an `IO` type, it is only `Stream` that does. But since `Stream` can only subtype a single abstract type, that is the only way to make it `Stream <: ... <: IO` such that the type hierarchy is preserved.

The potential drawback I see is that it probably causes more specialization, threading `Stream` through IO functions. At first I attempted to keep the more specific `read`/`write` methods for `Stream`, but because `Stream` is now an `IO` ambiguity errors pop up which require more methods to be defined manually to be resolved, at which point I thought having a minimal IO implementation might be better. I can try to maximally avoid specialization by adding these methods back, but it is quite likely that other ambiguity errors pop up in the future if going down that path. I believe that the invalidation fixes outweigh the added specialization.

I'm happy to discuss/drop this PR if the subtyping change it not desired, in which case we can try to come up with another solution to #396 (if it exists). I'm also curious to know if there was some discussion about having `Stream <: IO`, seeing that it implements lots of IO interface functions.