### PR TITLE
Introduce `HTTPExt` package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,17 @@
 name = "FileIO"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.16.5"
+version = "1.16.6"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[weakdeps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+
+[extensions]
+HTTPExt = "HTTP"
 
 [compat]
 Pkg = "<0.0.1, 0.7, 1"

--- a/ext/HTTPExt.jl
+++ b/ext/HTTPExt.jl
@@ -1,0 +1,13 @@
+module HTTPExt
+
+if isdefined(Base, :get_extension)
+    using FileIO
+    using HTTP
+else
+    using ..FileIO
+    using ..HTTP
+end
+
+FileIO.load(uri::HTTP.URI) = load(IOBuffer(HTTP.get(uri).body))
+
+end # module

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -64,11 +64,13 @@ include("registry.jl")
 """
 FileIO
 
+@static if !isdefined(Base, :get_extension)
 function __init__()
     @require HTTP="cd3eb016-35fb-5094-929b-558a96fad6f3" begin
-        load(uri::HTTP.URI) = load(IOBuffer(HTTP.get(uri).body))
+        include("../ext/HTTPExt.jl")
     end
 end
+end # @static
 
 if VERSION >= v"1.4.2" # https://github.com/JuliaLang/julia/pull/35378
     include("precompile.jl")


### PR DESCRIPTION
So the package is easier to statically precompile on newer Julia versions