### PR TITLE
Adjust to Julia 1.12 change to implicit world age increment

### DIFF
--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -401,7 +401,9 @@ end
 if VERSION >= v"1.3" begin
     @testset "CSV load from URL via CSVFiles (#320)" begin
         f = joinpath("files", "data.csv")
-        @test collect(load(f)) == collect(load("https://raw.githubusercontent.com/queryverse/CSVFiles.jl/v0.2.0/test/data.csv"))
+        c1 = load(f)
+        c2 = load("https://raw.githubusercontent.com/queryverse/CSVFiles.jl/v0.2.0/test/data.csv")
+        @test collect(c1) == collect(c2)
     end
 end
 


### PR DESCRIPTION
Julia 1.12 will no longer implicitly increment world ages within expressions. However, we will likely retain world age increments between statements of a `@testset`, so all that's needed here is to move the `load` to a separate like. More explicitly, the `collect`s could be `invokelatest`'ed instead. See https://github.com/JuliaLang/julia/pull/56509