### PR TITLE
fix stacktrace handling on nightly

### DIFF
--- a/src/error_handling.jl
+++ b/src/error_handling.jl
@@ -68,7 +68,13 @@ function handle_exceptions(exceptions::Vector, action)
     end
 end
 
-handle_error(e, q, bt) = throw(CapturedException(e, trim!(stacktrace(bt))))
+function handle_error(e, q, bt)
+    if VERSION >= v"1.13.0-DEV.927"
+        throw(CapturedException(e, bt))
+    else
+        throw(CapturedException(e, trim!(stacktrace(bt))))
+    end
+end
 
 function trim!(sfs)
     i = firstindex(sfs)


### PR DESCRIPTION
Before:

```
Expression: save("test.not_installed", nothing)
    Expected: CapturedException
      Thrown: MethodError
      MethodError: no method matching 
stacktrace(::Vector{Base.StackTraces.StackFrame})
      The function `stacktrace` exists, but no method is defined for 
this combination of argument types.
      Closest candidates are:
        stacktrace(::Bool)
         @ Base stacktraces.jl:206
        stacktrace()
         @ Base stacktraces.jl:206
        stacktrace(::Vector{<:Union{Ptr{Nothing}, Base.InterpreterIP}},
 ::Bool)
         @ Base stacktraces.jl:193
        ...
      Stacktrace:
        [1] CapturedException(ex::ArgumentError, 
bt_raw::Vector{Base.StackTraces.StackFrame})
          @ Base ./task.jl:17
        [2] handle_error(e::ArgumentError, q::Base.PkgId, 
bt::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}})
          @ FileIO 
~/PkgEval/problemos/FileIO.jl/src/error_handling.jl:71
        [3] handle_exceptions(exceptions::Vector{Tuple{Any, 
Union{Base.PkgId, Module}, Vector}}, action::String)
          @ FileIO 
~/PkgEval/problemos/FileIO.jl/src/error_handling.jl:66
        [4] action(call::Symbol, libraries::Vector{Union{Base.PkgId, 
Module}}, file::Formatted, args::Nothing; options::@Kwargs{})
          @ FileIO ~/PkgEval/problemos/FileIO.jl/src/loadsave.jl:228
        [5] action
          @ ~/PkgEval/problemos/FileIO.jl/src/loadsave.jl:196 [inlined]
        [6] action
          @ ~/PkgEval/problemos/FileIO.jl/src/loadsave.jl:185 [inlined]
        [7] save(file::String, args::Nothing; options::@Kwargs{})
          @ FileIO ~/PkgEval/problemos/FileIO.jl/src/loadsave.jl:129
        [8] save(file::String, args::Nothing)
          @ FileIO ~/PkgEval/problemos/FileIO.jl/src/loadsave.jl:125
```

Not sure how the `trim!` functionality should be restored. I'll open an issue about that.