### PR TITLE
Fix flaky OGG/MATROSKA test downloads

### DIFF
--- a/test/query.jl
+++ b/test/query.jl
@@ -408,9 +408,8 @@ let file_dir = joinpath(@__DIR__, "files"), file_path = Path(file_dir)
         function try_download(url)
             try
                 return Downloads.download(url)
-            catch e
-                e isa Downloads.RequestError && return nothing
-                rethrow()
+            catch
+                return nothing
             end
         end
         if Base.VERSION >= v"1.6" || !Sys.iswindows()


### PR DESCRIPTION
## Summary
- The `try_download` helper in tests caught only `Downloads.RequestError`, but this type check failed on some Julia versions when wikimedia returned HTTP 429 (rate limit)
- Changed to catch all exceptions, since any download failure should gracefully skip the test via `@test_skip`
- Fixes the CI failures seen in #429 (and likely other PRs hitting the same wikimedia rate limiting)

## Test plan
- [x] CI passes on all Julia versions (1.6, lts, nightly)
- [x] OGG/MATROSKA tests either pass (successful download) or skip gracefully (download failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)