### PR TITLE
Add metadata support for HTTP.URI

### DIFF
--- a/ext/HTTPExt.jl
+++ b/ext/HTTPExt.jl
@@ -9,5 +9,6 @@ else
 end
 
 FileIO.load(uri::HTTP.URI) = load(IOBuffer(HTTP.get(uri).body))
+FileIO.metadata(uri::HTTP.URI) = metadata(IOBuffer(HTTP.get(uri).body))
 
 end # module


### PR DESCRIPTION
## Summary
- Adds `FileIO.metadata(uri::HTTP.URI)` to the HTTP extension, matching the existing `FileIO.load(uri::HTTP.URI)` pattern
- Fixes #402

## Test plan
- [ ] `metadata(HTTP.URI("https://...some-image-url..."))` returns metadata instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)