### PR TITLE
Register Matlab .mat format with MAT.jl

### DIFF
--- a/src/registry.jl
+++ b/src/registry.jl
@@ -40,6 +40,7 @@ add_format(format"JLD2", (unsafe_wrap(Vector{UInt8},"Julia data file (HDF5), ver
            ".jld2", [:JLD2 => UUID("033835bb-8acc-5ee8-8aae-3f567f8a3819")])
 add_format(format"BSON", (), ".bson", [:BSON => UUID("fbb218c0-5317-5bc6-957e-2ee96dd4b1f0")])
 add_format(format"JLSO", (), ".jlso", [:JLSO => UUID("9da8a3cd-07a3-59c0-a743-3fdc52c30d11")])
+add_format(format"MAT", (), ".mat", [:MAT => UUID("23992714-dd62-5051-b70f-ba57cb901cac")])
 add_format(format"NPY", "\x93NUMPY", ".npy", [idNPZ])
 add_format(format"NPZ", "PK\x03\x04", ".npz", [idNPZ])
 


### PR DESCRIPTION
## Summary
- Registers `.mat` extension with `MAT.jl` (UUID `23992714-dd62-5051-b70f-ba57cb901cac`) so that `load("file.mat")` and `save("file.mat", data)` work via FileIO
- Fixes #361

## Test plan
- [x] CI passes
- [x] `using FileIO; query("test.mat")` returns `File{format"MAT"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)